### PR TITLE
[TBTC-10] implement 'burn' entrypoint variant

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -62,3 +62,5 @@ tests:
     - morley
     - fmt
     - containers
+    - lorentz-contracts
+    - named

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -180,9 +180,7 @@ mintParamParser =
        <*> (getParser "Amount to mint")
 
 burnParamsParser :: Opt.Parser BurnParams
-burnParamsParser =
-  (,) <$> (getParser "Address to burn from")
-       <*> (getParser "Amount to mint")
+burnParamsParser = getParser "Amount to burn"
 
 approveParamsParser :: Opt.Parser ApproveParams
 approveParamsParser =

--- a/src/Lorentz/Contracts/TZBTC.hs
+++ b/src/Lorentz/Contracts/TZBTC.hs
@@ -69,8 +69,8 @@ instance Buildable Parameter where
       "Get administrator"
     Mint (arg #to -> to, arg #value -> value) ->
       "Mint to " +| to |+ ", value = " +| value |+ ""
-    Burn (arg #from -> from, arg #value -> value) ->
-      "Burn from " +| from |+ ", value = " +| value |+ ""
+    Burn (arg #value -> value) ->
+      "Burn, value = " +| value |+ ""
     AddOperator (arg #operator -> operator) ->
       "Add operator " +| operator |+ ""
     RemoveOperator (arg #operator -> operator) ->

--- a/src/Lorentz/Contracts/TZBTC/Types.hs
+++ b/src/Lorentz/Contracts/TZBTC/Types.hs
@@ -33,7 +33,7 @@ import qualified Lorentz.Contracts.ManagedLedger.Types as ManagedLedger
 import Lorentz.Contracts.ManagedLedger.Types (Storage'(..), mkStorage')
 import Util.Instances ()
 
-type BurnParams = ("from" :! Address, "value" :! Natural)
+type BurnParams = ("value" :! Natural)
 type OperatorParams = ("operator" :! Address)
 type GetBalanceParams = Address
 type SetRedeemAddressParams = ("redeem" :! Address)
@@ -66,15 +66,18 @@ data Error
   | NotEnoughBalance ("required" :! Natural, "present" :! Natural)
     -- ^ Insufficient balance.
   | NotEnoughAllowance ("required" :! Natural, "present" :! Natural)
-    -- ^ Insufficient allowance to transfer foreign funds.
+    -- ^ Insufficient allowance to transfer funds.
   | OperationsArePaused
     -- ^ Operation is unavailable until resume by token admin.
   | NotInTransferOwnershipMode
     -- ^ For the `acceptOwnership` entry point, if the contract's `newOwner`
-    -- field is None
+    -- field is None.
   | SenderIsNotNewOwner
     -- ^ For the `acceptOwnership` entry point, if the sender is not the
-    -- address in the `newOwner` field
+    -- address in the `newOwner` field.
+  | SenderIsNotOperator
+    -- ^ For the burn/mint/pause entry point, if the sender is not one
+    -- of the operators.
   deriving stock (Eq, Generic)
 
 deriveCustomError ''Error

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,7 +13,7 @@ extra-deps:
     https://gitlab.com/morley-framework/morley.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    0f5d400a5d66b2b84b18b2d9dee72bf3eb48db58 # master
+    c4b9ca85437b6a25d37e9f52705240666864a168 # master
   subdirs:
     - .
     - lorentz-contracts

--- a/test.bats
+++ b/test.bats
@@ -19,8 +19,8 @@
 }
 
 @test "invoking tzbtc 'burn' command" {
-  result="$(stack exec -- tzbtc burn --from "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" --value 100)"
-  [ "$result" == '(Left (Right (Right (Right (Right (Pair "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" 100))))))' ]
+  result="$(stack exec -- tzbtc burn --value 100)"
+  [ "$result" == '(Left (Right (Right (Right (Right 100)))))' ]
 }
 
 @test "invoking tzbtc 'transfer' command" {
@@ -101,8 +101,8 @@
 }
 
 @test "invoking 'parseContractParameter' to parse burn parameter" {
-  raw_parameter="$(stack exec -- tzbtc burn --from tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx --value 100500)"
+  raw_parameter="$(stack exec -- tzbtc burn --value 100500)"
   exec_command="stack exec -- tzbtc parseContractParameter '${raw_parameter}'"
   result=$(eval $exec_command)
-  [ "$result" == 'Burn from tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx, value = 100500' ]
+  [ "$result" == 'Burn, value = 100500' ]
 }


### PR DESCRIPTION
<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description
Problem: Right now we are inheriting the burn command from managed ledger's interface. But the functionality is slightly different here. Here we should be able to burn from just one account. The one that has the address stored in the redeemAddress field. Thus the entry point for burn also does not accept an address parameter. 

Solution: Get the redeem address from storage and use it combined with the input parameter, to call the 'burn' entry point in managed ledger. The cli interface also had to be changed to not take an address parameter for burn command.

Tests: Adds a test that test the burn entry point and checks that the value is deducted from the balance in the address from the 'redeemAddress' field in storage. Tests for cli program also had to be changed to reflect the change in the parameter structure.

Depends on: https://issues.serokell.io/issue/TM-296

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-10

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
