### PR TITLE
[TBTC-12] Implement mint variant

### DIFF
--- a/src/Lorentz/Contracts/TZBTC/Impl.hs
+++ b/src/Lorentz/Contracts/TZBTC/Impl.hs
@@ -13,13 +13,13 @@ module Lorentz.Contracts.TZBTC.Impl
   , ManagedLedger.getAllowance
   , ManagedLedger.getBalance
   , ManagedLedger.getTotalSupply
-  , ManagedLedger.mint
   , ManagedLedger.setAdministrator
   , ManagedLedger.transfer
   , ManagedLedger.transfer'
   , acceptOwnership
   , addOperator
   , burn
+  , mint
   , migrate
   , pause
   , removeOperator
@@ -87,18 +87,44 @@ burn = do
     stackType @'[Storage' _]
   stackType @'["value" :! Natural, Storage' _]
   -- Now add the value to total burned field
-  -- Assuming totalSupply field to be amended by
-  -- ManagedLedger's burn procedure.
+  -- assuming totalSupply field to be update by
+  -- managedLedger's burn procedure.
   dip $ do
     dup
     toField #fields; getField #totalBurned
-  stackType @'["value" :! Natural, Natural, _, Storage' _]
   fromNamed #value
   add
   -- Update storage
   setField #totalBurned
   setField #fields
-  stackType @'[Storage' _]
+  finishNoOp
+
+mint :: forall fields. StorageFieldsC fields => Entrypoint MintParams fields
+mint = do
+  dip authorizeOperator
+  -- Make managed ledger's mint entrypoint parameter
+  stackType @'[("to" :! Address, "value" :! Natural), Storage' _]
+  dup
+  dip $ do
+    stackType @'[ManagedLedger.MintParams, Storage' _]
+    -- update ledger
+    ManagedLedger.creditTo
+    -- Drop mint prameters
+    drop
+    stackType @'[Storage' _]
+  cdr
+  stackType @'["value" :! Natural, Storage' _]
+  -- Now add the value to total minted field
+  -- assuming totalSupply field to be updated by
+  -- managedLedger's mint procedure.
+  dip $ do
+    dup
+    toField #fields; getField #totalMinted
+  fromNamed #value
+  add
+  -- Update storage
+  setField #totalMinted
+  setField #fields
   finishNoOp
 
 -- | Add a new operator to the set of Operators. Only admin is allowed to call this


### PR DESCRIPTION
<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

Right now we are inheriting the mint command from managed
ledger's interface. But the functionality is slightly different here.
Here we should only accept invocations from operators. It should also
update `totalMinted` in addition to the `totalSupply` field in storage.

Here also we are not able to call manage ledger's entry point directly, since
it checks for sender to be admin. So the `creditTo` function and dependencies 
were moved here and called from a new entry point that only checked the sender
to be one of the operators.

Tests that cover all the expected behavior has been added.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-12

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
