### PR TITLE
[TBTC-13] Permission check variation for pause/unpause entry points

### DIFF
--- a/src/Lorentz/Contracts/TZBTC/Impl.hs
+++ b/src/Lorentz/Contracts/TZBTC/Impl.hs
@@ -228,9 +228,11 @@ migrate = stub
 -- | Pause end user actions. This is callable only by the operators.
 pause :: StorageFieldsC fields => Entrypoint () fields
 pause = do
+  dip authorizeOperator
   drop
   push True
-  ManagedLedger.setPause
+  dip (getField #fields); setField #paused; setField #fields
+  nil; pair
 
 -- | Resume end user actions if the contract is in a paused state.
 -- This is callable only by the admin.

--- a/test/Test/TZBTC.hs
+++ b/test/Test/TZBTC.hs
@@ -11,6 +11,8 @@ module Test.TZBTC
   , test_acceptOwnership
   , test_burn
   , test_mint
+  , test_pause
+  , test_unpause_
   ) where
 
 import Fmt (pretty)
@@ -28,7 +30,7 @@ import Michelson.Interpret (ContractEnv(..), MichelsonFailed(..))
 import Michelson.Runtime.GState
 import Michelson.Test (ContractPropValidator, contractProp, dummyContractEnv)
 import Michelson.Text (mt)
-import Michelson.Typed (Instr, ToTs, Value'(..))
+import Michelson.Typed (Instr, ToTs, Value, Value'(..))
 import Util.Named
 
 lContract :: Instr (ToTs '[(Parameter, Storage)]) (ToTs (ContractOut Storage))
@@ -55,11 +57,6 @@ contractAddress = genesisAddress4
 alice :: Address
 alice = genesisAddress6
 
-contractEnv :: ContractEnv
-contractEnv =
-  dummyContractEnv
-    { ceSender = adminAddress }
-
 initialSupply :: Natural
 initialSupply = 500
 
@@ -68,58 +65,70 @@ storage =
   mkStorage adminAddress redeemAddress_
     (Map.fromList [(redeemAddress_, initialSupply)]) mempty
 
+contractPropWithSender
+  :: Address
+  -> ContractPropValidator (ToT Storage) prop
+  -> Parameter
+  -> Storage
+  -> prop
+contractPropWithSender address_ check param initSt =
+  contractProp lContract check
+    (dummyContractEnv { ceSender = address_ })
+    param
+    initSt
+
+assertFailureMessage
+  :: Either MichelsonFailed ([Operation], Value (ToT Storage))
+  -> MText
+  -> String
+  -> Assertion
+assertFailureMessage res msg tstMsg = case res of
+  Right (_, _) ->
+    assertFailure "Contract did not fail as expected"
+  Left err -> case err of
+    MichelsonFailedWith (VPair ((VC (CvString t)), _)) -> do
+      assertEqual tstMsg msg t
+    a -> assertFailure $ "Unexpected contract failure: " <> pretty a
+
 test_adminCheck :: TestTree
 test_adminCheck = testGroup "TZBTC contract admin check test"
   [ testCase "Fails with `SenderNotAdmin` if sender is not administrator for `addOperator` call" $
-      contractProp lContract
-        validate' badContractEnv (AddOperator (#operator .! newOperatorAddress)) storage
+      contractPropWithSender badAdminAddress validate'
+        (AddOperator (#operator .! newOperatorAddress)) storage
   , testCase
       "Fails with `SenderNotAdmin` if sender is not administrator for `removeOperator` call" $
-      contractProp lContract
-        validate' badContractEnv (RemoveOperator (#operator .! newOperatorAddress)) storage
+      contractPropWithSender badAdminAddress validate'
+        (RemoveOperator (#operator .! newOperatorAddress)) storage
   , testCase
       "Fails with `SenderNotAdmin` if sender is not administrator for `startMigrateFrom` call" $
-      contractProp lContract
-        validate' badContractEnv (StartMigrateFrom (#migratefrom .! contractAddress)) storage
+      contractPropWithSender badAdminAddress validate'
+        (StartMigrateFrom (#migratefrom .! contractAddress)) storage
   , testCase
       "Fails with `SenderNotAdmin` if sender is not administrator for `startMigrateTo` call" $
-      contractProp lContract
-        validate' badContractEnv (StartMigrateTo (#migrateto .! contractAddress)) storage
+      contractPropWithSender badAdminAddress validate'
+        (StartMigrateTo (#migrateto .! contractAddress)) storage
   , testCase
       "Fails with `SenderNotAdmin` if sender is not administrator for `transferOwnership` call" $
-      contractProp lContract
-        validate' badContractEnv (TransferOwnership (#newowner .! adminAddress)) storage
+      contractPropWithSender badAdminAddress validate'
+        (TransferOwnership (#newowner .! adminAddress)) storage
   , testCase
       "Fails with `SenderNotAdmin` if sender is not administrator for `setRedeemAddress` call" $
-      contractProp lContract
-        validate' badContractEnv (SetRedeemAddress (#redeem .! redeemAddress_)) storage
+      contractPropWithSender badAdminAddress validate'
+        (SetRedeemAddress (#redeem .! redeemAddress_)) storage
   ]
   where
-    badContractEnv :: ContractEnv
-    badContractEnv =
-      dummyContractEnv
-        { ceSender = badAdminAddress }
-
     validate' :: ContractPropValidator (ToT Storage) Assertion
     validate' (res, _) =
-      case res of
-        Left err -> do
-          case err of
-            MichelsonFailedWith (VPair ((VC (CvString t)), _)) ->
-              assertEqual
-                "Contract did not fail with 'SenderIsNotAdmin' message"
-                 [mt|SenderIsNotAdmin|]
-                 t
-            a -> assertFailure $ "Unexpected contract failure: " <> pretty a
-        Right (_operations, _) ->
-          assertFailure "Contract did not fail as expected"
+      assertFailureMessage
+        res [mt|SenderIsNotAdmin|]
+        "Contract did not fail with 'SenderIsNotAdmin' message"
 
 test_addOperator :: TestTree
 test_addOperator = testGroup "TZBTC contract `addOperator` test"
   [ testCase
       "Call to `addOperator` Adds new operator to the set of operators" $
-      contractProp lContract
-        validateAdd contractEnv (AddOperator (#operator .! newOperatorAddress)) storage
+      contractPropWithSender adminAddress
+        validateAdd (AddOperator (#operator .! newOperatorAddress)) storage
   ]
   where
     validateAdd :: ContractPropValidator (ToT Storage) Assertion
@@ -134,9 +143,9 @@ test_removeOperator :: TestTree
 test_removeOperator = testGroup "TZBTC contract `removeOperator` test"
   [ testCase
       "Call to `removeOperator` removes operator from the set of operators" $
-      contractProp lContract
+      contractPropWithSender adminAddress
         validateRemove
-        contractEnv (RemoveOperator (#operator .! operatorToRemove)) storageWithOperator
+        (RemoveOperator (#operator .! operatorToRemove)) storageWithOperator
   ]
   where
     operatorToRemove = replaceAddress
@@ -153,8 +162,8 @@ test_setRedeemAddress :: TestTree
 test_setRedeemAddress = testGroup "TZBTC contract `setRedeemAddress` test"
   [ testCase
       "Call to `setRedeemAddress` updates redeemAddress" $
-      contractProp lContract
-        validate_ contractEnv (SetRedeemAddress (#redeem .! newRedeemAddress)) storage
+      contractPropWithSender adminAddress
+        validate_ (SetRedeemAddress (#redeem .! newRedeemAddress)) storage
   ]
   where
     newRedeemAddress = replaceAddress
@@ -172,8 +181,8 @@ test_transferOwnership :: TestTree
 test_transferOwnership = testGroup "TZBTC contract `transferOwnership` test"
   [ testCase
       "Call to `transferOwnership` updates `newOwner`" $
-      contractProp lContract
-        validate_ contractEnv (TransferOwnership (#newowner .! newOwnerAddress)) storage
+      contractPropWithSender adminAddress
+        validate_ (TransferOwnership (#newowner .! newOwnerAddress)) storage
   ]
   where
     newOwnerAddress = replaceAddress
@@ -191,57 +200,35 @@ test_acceptOwnership :: TestTree
 test_acceptOwnership = testGroup "TZBTC contract `acceptOwnership` test"
   [ testCase
       "Call to `acceptOwnership` get denied on contract that is not in transfer mode" $
-      contractProp lContract
-        validateNotInTransfer contractEnvWithGoodSender (AcceptOwnership ()) storage
+      contractPropWithSender newOwnerAddress
+        validateNotInTransfer (AcceptOwnership ()) storage
   , testCase
       "Call to `acceptOwnership` fails for bad caller" $
-      contractProp lContract
-        validateBadSender contractEnvWithBadSender (AcceptOwnership ()) storageInTranferOwnership
+      contractPropWithSender badSenderAddress
+        validateBadSender (AcceptOwnership ()) storageInTranferOwnership
   , testCase
       "Call to `acceptOwnership` updates admin with address of new owner" $
-      contractProp lContract
-        validateGoodOwner contractEnvWithGoodSender (AcceptOwnership ()) storageInTranferOwnership
+      contractPropWithSender newOwnerAddress
+        validateGoodOwner (AcceptOwnership ()) storageInTranferOwnership
   ]
   where
     newOwnerAddress = replaceAddress
     badSenderAddress = genesisAddress1
-    contractEnvWithBadSender =
-      dummyContractEnv
-        { ceSender = badSenderAddress }
-    contractEnvWithGoodSender =
-      dummyContractEnv
-        { ceSender = newOwnerAddress }
     storageInTranferOwnership = let
       f = fields storage
       in storage { fields = f { newOwner = Just newOwnerAddress } }
 
     validateNotInTransfer :: ContractPropValidator (ToT Storage) Assertion
     validateNotInTransfer (res, _) =
-      case res of
-        Left err -> do
-          case err of
-            MichelsonFailedWith (VPair ((VC (CvString t)), _)) ->
-              assertEqual
-                "Contract did not fail with 'NotInTransferOwnershipMode' message"
-                 [mt|NotInTransferOwnershipMode|]
-                 t
-            a -> assertFailure $ "Unexpected contract failure: " <> pretty a
-        Right (_operations, _) ->
-          assertFailure "Contract did not fail as expected"
+      assertFailureMessage
+        res [mt|NotInTransferOwnershipMode|]
+          "Contract did not fail with 'NotInTransferOwnershipMode' message"
 
     validateBadSender :: ContractPropValidator (ToT Storage) Assertion
     validateBadSender (res, _) =
-      case res of
-        Left err -> do
-          case err of
-            MichelsonFailedWith (VPair ((VC (CvString t)), _)) ->
-              assertEqual
-                "Contract did not fail with 'SenderIsNotNewOwner' message"
-                 [mt|SenderIsNotNewOwner|]
-                 t
-            a -> assertFailure $ "Unexpected contract failure: " <> pretty a
-        Right (_operations, _) ->
-          assertFailure "Contract did not fail as expected"
+      assertFailureMessage
+        res [mt|SenderIsNotNewOwner|]
+          "Contract did not fail with 'SenderIsNotNewOwner' message"
 
     validateGoodOwner :: ContractPropValidator (ToT Storage) Assertion
     validateGoodOwner (res, _) =
@@ -261,32 +248,23 @@ test_burn :: TestTree
 test_burn = testGroup "TZBTC contract `burn` test"
   [ testCase
       "Call to `burn` gets denied with `SenderIsNotOperator`" $
-      contractProp lContract
-        validateFail_ contractEnv (Burn (#value .! 100)) storageWithOperator
+      contractPropWithSender adminAddress
+        validateFail_ (Burn (#value .! 100)) storageWithOperator
   , testCase
       "Call to `burn` burns from `redeemAddress` and update `totalBurned` \
       \ and `totalSupply` fields correctly" $
-      contractProp lContract
-        validate_ contractEnvWithOperatorSender (Burn (#value .! 100)) storageWithOperator
+      contractPropWithSender newOperatorAddress
+        validate_ (Burn (#value .! 100)) storageWithOperator
   ]
   where
-    contractEnvWithOperatorSender = contractEnv { ceSender = newOperatorAddress }
     storageWithOperator =
       mkStorage adminAddress redeemAddress_
         (Map.fromList [(redeemAddress_, initialSupply)]) (Set.fromList [newOperatorAddress])
     validateFail_ :: ContractPropValidator (ToT Storage) Assertion
     validateFail_ (res, _) =
-      case res of
-        Left err -> do
-          case err of
-            MichelsonFailedWith (VPair ((VC (CvString t)), _)) ->
-              assertEqual
-                "Contract did not fail with 'SenderIsNotOperator' message"
-                 [mt|SenderIsNotOperator|]
-                 t
-            a -> assertFailure $ "Unexpected contract failure: " <> pretty a
-        Right (_operations, _) ->
-          assertFailure "Contract did not fail as expected"
+      assertFailureMessage
+        res [mt|SenderIsNotOperator|]
+          "Contract did not fail with 'SenderIsNotOperator' message"
 
     validate_ :: ContractPropValidator (ToT Storage) Assertion
     validate_ (res, _) =
@@ -313,32 +291,23 @@ test_mint :: TestTree
 test_mint = testGroup "TZBTC contract `mint` test"
   [ testCase
       "Call to `mint` gets denied with `SenderIsNotOperator`" $
-      contractProp lContract
-        validateFail_ contractEnv (Burn (#value .! 100)) storageWithOperator
+      contractPropWithSender adminAddress
+        validateFail_ (Burn (#value .! 100)) storageWithOperator
   , testCase
       "Call to `mint` adds value to `to` parameter in input and update `totalMinted` \
       \ and `totalSupply` fields correctly" $
-      contractProp lContract
-        validate_ contractEnvWithOperatorSender (Mint (#to .! alice, #value .! 200)) storageWithOperator
+      contractPropWithSender newOperatorAddress
+        validate_ (Mint (#to .! alice, #value .! 200)) storageWithOperator
   ]
   where
-    contractEnvWithOperatorSender = contractEnv { ceSender = newOperatorAddress }
     storageWithOperator =
       mkStorage adminAddress redeemAddress_
         (Map.fromList [(redeemAddress_, initialSupply)]) (Set.fromList [newOperatorAddress])
     validateFail_ :: ContractPropValidator (ToT Storage) Assertion
     validateFail_ (res, _) =
-      case res of
-        Left err -> do
-          case err of
-            MichelsonFailedWith (VPair ((VC (CvString t)), _)) ->
-              assertEqual
-                "Contract did not fail with 'SenderIsNotOperator' message"
-                 [mt|SenderIsNotOperator|]
-                 t
-            a -> assertFailure $ "Unexpected contract failure: " <> pretty a
-        Right (_operations, _) ->
-          assertFailure "Contract did not fail as expected"
+      assertFailureMessage
+        res [mt|SenderIsNotOperator|]
+          "Contract did not fail with 'SenderIsNotOperator' message"
 
     validate_ :: ContractPropValidator (ToT Storage) Assertion
     validate_ (res, _) =
@@ -360,3 +329,65 @@ test_mint = testGroup "TZBTC contract `mint` test"
             "Contract's `mint` operation did not update `totalSupply` field correctly"
              700
              (totalSupply $ fields $ (fromVal rstorage :: Storage))
+
+test_pause :: TestTree
+test_pause = testGroup "TZBTC contract `pause` permission test"
+  [ testCase
+      "Call to `pause` gets denied with `SenderIsNotOperator`" $
+      contractPropWithSender adminAddress
+        validateFail_ (Pause ()) storageWithOperator
+  , testCase
+      "Call to `pause` as operator is allowed" $
+      contractPropWithSender newOperatorAddress
+        validate_ (Pause ()) storageWithOperator
+  ]
+  where
+    storageWithOperator =
+      mkStorage adminAddress redeemAddress_
+        (Map.fromList [(redeemAddress_, initialSupply)]) (Set.fromList [newOperatorAddress])
+    validateFail_ :: ContractPropValidator (ToT Storage) Assertion
+    validateFail_ (res, _) =
+      assertFailureMessage
+        res [mt|SenderIsNotOperator|]
+          "Contract did not fail with 'SenderIsNotOperator' message"
+
+    validate_ :: ContractPropValidator (ToT Storage) Assertion
+    validate_ (res, _) =
+      case res of
+        Left err -> assertFailure $ "Unexpected contract failure: " <> pretty err
+        Right (_operations, rstorage) ->
+          assertEqual
+            "Contract's `pause` operation executed with out error"
+             True
+             (paused $ fields $ (fromVal rstorage :: Storage))
+
+test_unpause_ :: TestTree
+test_unpause_ = testGroup "TZBTC contract `unpause` permission test"
+  [ testCase
+      "Call to `unpause` as operator gets denied with `SenderIsNotAdmin`" $
+      contractPropWithSender newOperatorAddress
+        validateFail_ (Unpause ()) storageWithOperator
+  , testCase
+      "Call to `unpause` as admin is allowed" $
+      contractPropWithSender adminAddress
+        validate_ (Unpause ()) storageWithOperator
+  ]
+  where
+    storageWithOperator =
+      mkStorage adminAddress redeemAddress_
+        (Map.fromList [(redeemAddress_, initialSupply)]) (Set.fromList [newOperatorAddress])
+    validateFail_ :: ContractPropValidator (ToT Storage) Assertion
+    validateFail_ (res, _) =
+      assertFailureMessage
+        res [mt|SenderIsNotAdmin|]
+        "Contract did not fail with 'SenderIsNotAdmin' message"
+
+    validate_ :: ContractPropValidator (ToT Storage) Assertion
+    validate_ (res, _) =
+      case res of
+        Left err -> assertFailure $ "Unexpected contract failure: " <> pretty err
+        Right (_operations, rstorage) ->
+          assertEqual
+            "Contract's `unpause` operation executed with out error"
+             False
+             (paused $ fields $ (fromVal rstorage :: Storage))


### PR DESCRIPTION
<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

The pause/unpause endpoints inherited from managed ledger requires
admin for both the entry points. But here we want to allow operators
to pause, but not unpause, and only admins to be able to unpause.

All the tests for contract has been refactored to reduce some duplication. 
Attempt have been made to add new tests that cover all behavior..

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-13

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
