### PR TITLE
[TBTC-14] Migration entrypoints

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,14 +14,15 @@ import Options.Applicative
   (execParser, footerDoc, fullDesc, header, help, helper, info, infoOption, long, progDesc)
 import Options.Applicative.Help.Pretty (Doc, linebreak)
 
-import Lorentz (Address, parseLorentzValue, printLorentzContract, printLorentzValue)
+import Lorentz (Address, parseLorentzValue, printLorentzContract, printLorentzValue, lcwDumb)
 import Lorentz.Common (TestScenario, showTestScenario)
 import Util.Named ((.!))
 import Util.IO (writeFileUtf8)
 import Paths_tzbtc (version)
 
 import CLI.Parser
-import Lorentz.Contracts.TZBTC (Parameter(..), mkStorage, tzbtcCompileWay, tzbtcContract)
+import Lorentz.Contracts.TZBTC
+  (Parameter(..), agentContract, mkStorage, tzbtcCompileWay, tzbtcContract)
 
 -- Here in main function we will just accept commands from user
 -- and print the smart contract parameter by using `printLorentzValue`
@@ -51,6 +52,15 @@ main = do
     CmdPrintContract singleLine mbFilePath ->
       maybe putStrLn writeFileUtf8 mbFilePath $
         printLorentzContract singleLine tzbtcCompileWay tzbtcContract
+    CmdPrintAgentContract singleLine mbFilePath ->
+      maybe putStrLn writeFileUtf8 mbFilePath $
+        printLorentzContract singleLine lcwDumb (agentContract @Parameter)
+        -- Here agentContract that is printed is the one that target a
+        -- contract with the parameter `Parameter`. If we can obtain
+        -- runtime witness or type class dictionaries for the constraints
+        -- `agentContract` require it might be possible to read a contract
+        -- from a file, and printout an agent contract that can migrate
+        -- to it, or print out an error if it is incompatible.
     CmdPrintInitialStorage adminAddress redeemAddress ->
       putStrLn $ printLorentzValue True (mkStorage adminAddress redeemAddress mempty mempty)
     CmdParseParameter t ->

--- a/package.yaml
+++ b/package.yaml
@@ -48,7 +48,6 @@ executables:
       - safe-exceptions
       - tzbtc
 
-
 tests:
   tzbtc-test:
     <<: *test-common
@@ -65,5 +64,6 @@ tests:
     - morley
     - fmt
     - containers
+    - singletons
     - lorentz-contracts
     - named

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -43,6 +43,7 @@ data CmdLnArgs
   | CmdMigrate MigrateParams
   | CmdPrintInitialStorage Address Address
   | CmdPrintContract Bool (Maybe FilePath)
+  | CmdPrintAgentContract Bool (Maybe FilePath)
   | CmdParseParameter Text
   | CmdTestScenario TestScenarioOptions
 
@@ -59,7 +60,8 @@ argParser = hsubparser $
   <> removeOperatorCmd <> pauseCmd <> unpauseCmd
   <> setRedeemAddressCmd <> transferOwnershipCmd
   <> startMigrateFromCmd <> startMigrateToCmd
-  <> migrateCmd <> printCmd <> printInitialStorageCmd
+  <> migrateCmd <> printCmd
+  <> printAgentCmd <> printInitialStorageCmd
   <> parseParameterCmd <> testScenarioCmd
   where
     mkCommandParser ::
@@ -77,6 +79,14 @@ argParser = hsubparser $
              "printContract"
              (CmdPrintContract <$> singleLineSwitch <*> outputOption)
              "Print token contract")
+    printAgentCmd :: Opt.Mod Opt.CommandFields CmdLnArgs
+    printAgentCmd =
+      let singleLineSwitch =
+            switch (long "oneline" <> help "Single line output")
+       in (mkCommandParser
+             "printAgentContract"
+             (CmdPrintAgentContract <$> singleLineSwitch <*> outputOption)
+             "Print migration agent contract")
     printInitialStorageCmd :: Opt.Mod Opt.CommandFields CmdLnArgs
     printInitialStorageCmd =
       (mkCommandParser
@@ -227,14 +237,16 @@ setRedeemAddressParamsParser :: Opt.Parser SetRedeemAddressParams
 setRedeemAddressParamsParser = #redeem <.!> addressArgument "Redeem address"
 
 transferOwnershipParamsParser :: Opt.Parser TransferOwnershipParams
-transferOwnershipParamsParser = #newowner
+transferOwnershipParamsParser = #newOwner
   <.!> addressArgument "Address of the new owner"
 
 startMigrateFromParamsParser :: Opt.Parser StartMigrateFromParams
-startMigrateFromParamsParser = #migratefrom <.!> addressArgument "Source contract address"
+startMigrateFromParamsParser = #migrationManager <.!>
+  (ContractAddr <$> addressArgument "Source contract address")
 
 startMigrateToParamsParser :: Opt.Parser StartMigrateToParams
-startMigrateToParamsParser = #migrateto <.!> addressArgument "Destination contract address"
+startMigrateToParamsParser = #migrationManager <.!>
+  (ContractAddr <$> addressArgument "Manager contract address")
 
 -- Maybe add default value and make sure it will be shown in help message.
 maybeAddDefault :: Opt.HasValue f => (a -> String) -> Maybe a -> Opt.Mod f a

--- a/src/Lorentz/Contracts/TZBTC.hs
+++ b/src/Lorentz/Contracts/TZBTC.hs
@@ -10,93 +10,19 @@ module Lorentz.Contracts.TZBTC
   , Parameter(..)
   , Storage
   , StorageFields(..)
+  , agentContract
   , tzbtcContract
   , tzbtcCompileWay
   ) where
 
-import Fmt (Buildable(..), (+|), (|+))
 
 import Lorentz
 
+import Lorentz.Contracts.TZBTC.Agent (agentContract)
 import Lorentz.Contracts.TZBTC.Impl
 import Lorentz.Contracts.TZBTC.Types
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
-
-----------------------------------------------------------------------------
--- Parameter
-----------------------------------------------------------------------------
-
-data Parameter
-  = Transfer            !TransferParams
-  | Approve             !ApproveParams
-  | GetAllowance        !(View GetAllowanceParams Natural)
-  | GetBalance          !(View Address Natural)
-  | GetTotalSupply      !(View () Natural)
-  | GetTotalMinted      !(View () Natural)
-  | GetTotalBurned      !(View () Natural)
-  | SetAdministrator    !Address
-  | GetAdministrator    !(View () Address)
-  | Mint                !MintParams
-  | Burn                !BurnParams
-  | AddOperator         !OperatorParams
-  | RemoveOperator      !OperatorParams
-  | SetRedeemAddress    !SetRedeemAddressParams
-  | Pause               !()
-  | Unpause             !()
-  | TransferOwnership   !TransferOwnershipParams
-  | AcceptOwnership     !AcceptOwnershipParams
-  | StartMigrateTo      !StartMigrateToParams
-  | StartMigrateFrom    !StartMigrateFromParams
-  | Migrate             !MigrateParams
-  deriving stock Generic
-  deriving anyclass IsoValue
-
-
-instance Buildable Parameter where
-  build = \case
-    Transfer (arg #from -> from, arg #to -> to, arg #value -> value) ->
-      "Transfer from " +| from |+ " to " +| to |+ ", value = " +| value |+ ""
-    Approve (arg #spender -> spender, arg #value -> value) ->
-      "Approve for " +| spender |+ ", value = " +| value |+ ""
-    GetAllowance (View (arg #owner -> owner, arg #spender -> spender) _) ->
-      "Get allowance for " +| owner |+ " from " +| spender |+ ""
-    GetBalance (View addr _) ->
-      "Get balance for " +| addr |+ ""
-    GetTotalSupply _ ->
-      "Get total supply"
-    GetTotalMinted _ ->
-      "Get total minted"
-    GetTotalBurned _ ->
-      "Get total burned"
-    SetAdministrator addr ->
-      "Set administrator to " +| addr |+ ""
-    GetAdministrator _ ->
-      "Get administrator"
-    Mint (arg #to -> to, arg #value -> value) ->
-      "Mint to " +| to |+ ", value = " +| value |+ ""
-    Burn (arg #value -> value) ->
-      "Burn, value = " +| value |+ ""
-    AddOperator (arg #operator -> operator) ->
-      "Add operator " +| operator |+ ""
-    RemoveOperator (arg #operator -> operator) ->
-      "Remove operator " +| operator |+ ""
-    SetRedeemAddress (arg #redeem -> redeem) ->
-      "Set redeem address to " +| redeem |+ ""
-    Pause _ ->
-      "Pause"
-    Unpause _ ->
-      "Unpause"
-    TransferOwnership (arg #newowner -> newOwner) ->
-      "Transfer ownership to " +| newOwner |+ ""
-    AcceptOwnership _ ->
-      "Accept ownership"
-    StartMigrateTo (arg #migrateto -> migrateTo) ->
-      "Start migrate to " +| migrateTo |+ ""
-    StartMigrateFrom (arg #migratefrom -> migrateFrom) ->
-      "Start migrate from " +| migrateFrom |+ ""
-    Migrate _ ->
-      "Migrate"
 
 ----------------------------------------------------------------------------
 -- Implementation
@@ -126,6 +52,7 @@ tzbtcContract = do
     , #cAcceptOwnership /-> acceptOwnership
     , #cStartMigrateTo /-> startMigrateTo
     , #cStartMigrateFrom /-> startMigrateFrom
+    , #cMintForMigration /-> mintForMigration
     , #cMigrate /-> migrate
     )
 

--- a/src/Lorentz/Contracts/TZBTC/Agent.hs
+++ b/src/Lorentz/Contracts/TZBTC/Agent.hs
@@ -1,0 +1,79 @@
+{- SPDX-FileCopyrightText: 2019 Bitcoin Suisse
+ -
+ - SPDX-License-Identifier: LicenseRef-Proprietary
+ -}
+{-# LANGUAGE RebindableSyntax #-}
+{-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
+
+module Lorentz.Contracts.TZBTC.Agent
+  ( Parameter
+  , StorageFields(..)
+  , agentContract
+  , Error(..)
+  ) where
+
+import Lorentz
+import Michelson.Typed.Haskell.Instr.Sum
+
+----------------------------------------------------------------------------
+-- Implementation
+----------------------------------------------------------------------------
+type Parameter = (Address, Natural)
+
+data StorageFields tp = StorageFields
+  { oldVersion :: Address
+  , newVersion :: ContractAddr tp
+  } deriving stock Generic
+    deriving anyclass IsoValue
+
+data Error
+  = MigrationBadOrigin
+  deriving stock (Eq, Generic)
+
+deriveCustomError ''Error
+
+-- | A migration agent that can migrate to any contract as long as the
+-- target contract have a constructor/entrypoint `MintForMigration` with field
+-- ("to" :! Address, "value" :! Natural)
+agentContract
+  :: forall parameter.
+  ( InstrWrapC parameter "cMintForMigration"
+  , AppendCtorField
+      (GetCtorField parameter "cMintForMigration") '[]
+    ~ '[("to" :! Address, "value" :! Natural)]
+  , KnownValue parameter, NoOperation parameter, NoBigMap parameter
+  ) => Contract Parameter (StorageFields parameter)
+agentContract = do
+  -- Pack input into parameter of target contract
+  stackType @('[((Address, Natural), StorageFields parameter)])
+  unpair
+  dip ensureOldContract
+  stackType @('[(Address, Natural), StorageFields parameter])
+  unpair
+  toNamed #to
+  dip $ toNamed #value
+  pair
+  stackType @('[("to" :! Address, "value" :! Natural), StorageFields parameter])
+  swap
+  dip $ do
+    wrap_ @parameter #cMintForMigration
+    stackType @('[parameter])
+  swap
+  stackType @('[parameter, StorageFields parameter])
+  -- Get new contract address from storage
+  -- and call it passing the input paramter
+  dip $ do
+    dup
+    toField #newVersion
+    push (toMutez 0)
+  stackType @('[parameter, Mutez, ContractAddr parameter, StorageFields parameter])
+  transferTokens
+  dip nil; cons;
+  pair
+    where
+      ensureOldContract = do
+        getField #oldVersion
+        sender
+        if IsEq then
+          nop
+        else failUsing MigrationBadOrigin

--- a/src/Lorentz/Contracts/TZBTC/Types.hs
+++ b/src/Lorentz/Contracts/TZBTC/Types.hs
@@ -15,17 +15,22 @@ module Lorentz.Contracts.TZBTC.Types
   , ManagedLedger.Storage' (..)
   , ManagedLedger.TransferParams
   , MigrateParams
+  , MigrationManager
   , OperatorParams
+  , Parameter(..)
   , PauseParams
   , SetRedeemAddressParams
+  , SetMigrationAgentParams
   , StartMigrateFromParams
   , StartMigrateToParams
+  , MintForMigrationParams
   , Storage
   , StorageFields(..)
   , TransferOwnershipParams
   , mkStorage
   ) where
 
+import Fmt (Buildable(..), (+|), (|+))
 import Data.Set (Set)
 
 import Lorentz
@@ -33,16 +38,53 @@ import qualified Lorentz.Contracts.ManagedLedger.Types as ManagedLedger
 import Lorentz.Contracts.ManagedLedger.Types (Storage'(..), mkStorage')
 import Util.Instances ()
 
+type MigrationManager = ContractAddr (Address, Natural)
 type BurnParams = ("value" :! Natural)
 type OperatorParams = ("operator" :! Address)
 type GetBalanceParams = Address
 type SetRedeemAddressParams = ("redeem" :! Address)
 type PauseParams = Bool
-type TransferOwnershipParams = ("newowner" :! Address)
-type StartMigrateToParams = ("migrateto" :! Address)
-type StartMigrateFromParams = ("migratefrom" :! Address)
+type TransferOwnershipParams = ("newOwner" :! Address)
+type StartMigrateToParams = ("migrationManager" :! MigrationManager)
+type StartMigrateFromParams = ("migrationManager" :! MigrationManager)
+type MintForMigrationParams = ("to" :! Address, "value" :! Natural)
 type AcceptOwnershipParams = ()
 type MigrateParams = ()
+type SetMigrationAgentParams = ("migrationAgent" :! MigrationManager)
+
+----------------------------------------------------------------------------
+-- Parameter
+----------------------------------------------------------------------------
+
+data Parameter
+  = Transfer            !ManagedLedger.TransferParams
+  | Approve             !ManagedLedger.ApproveParams
+  | GetAllowance        !(View ManagedLedger.GetAllowanceParams Natural)
+  | GetBalance          !(View Address Natural)
+  | GetTotalSupply      !(View () Natural)
+  | GetTotalMinted      !(View () Natural)
+  | GetTotalBurned      !(View () Natural)
+  | SetAdministrator    !Address
+  | GetAdministrator    !(View () Address)
+  | Mint                !ManagedLedger.MintParams
+  | Burn                !BurnParams
+  | AddOperator         !OperatorParams
+  | RemoveOperator      !OperatorParams
+  | SetRedeemAddress    !SetRedeemAddressParams
+  | Pause               !()
+  | Unpause             !()
+  | TransferOwnership   !TransferOwnershipParams
+  | AcceptOwnership     !AcceptOwnershipParams
+  | StartMigrateTo      !StartMigrateToParams
+  | StartMigrateFrom    !StartMigrateFromParams
+  | MintForMigration    !MintForMigrationParams
+  | Migrate             !MigrateParams
+  deriving stock Generic
+  deriving anyclass IsoValue
+
+----------------------------------------------------------------------------
+-- Storage
+----------------------------------------------------------------------------
 
 data StorageFields = StorageFields
   { admin       :: Address
@@ -52,11 +94,11 @@ data StorageFields = StorageFields
   , totalMinted :: Natural
   , newOwner    :: Maybe Address
   , operators   :: Set Address
-  , migrateFrom :: Maybe Address
-  , migrateTo   :: Maybe Address
   , redeemAddress :: Address
   , code :: MText
   , tokenname :: MText
+  , migrationManagerIn :: Maybe MigrationManager
+  , migrationManagerOut :: Maybe MigrationManager
   } deriving stock Generic
     deriving anyclass IsoValue
 
@@ -80,7 +122,68 @@ data Error
   | SenderIsNotOperator
     -- ^ For the burn/mint/pause entry point, if the sender is not one
     -- of the operators.
+  | UnauthorizedMigrateFrom
+    -- ^ For migration calls if the contract does not have previous
+    -- version field set.
+  | NoBalanceToMigrate
+    -- ^ For migration calls if there is nothing to migrate.
+  | MigrationNotEnabled
+    -- ^ For migrate calls to contracts don't have migration manager set.
+  | SenderIsNotAgent
+    -- ^ For `mintForMigration` calls from address other than that of the
+    -- migration agent.
+  | ContractIsNotPaused
+    -- ^ For `startMigrateTo` calls when the contract is in a running state
+  | ContractIsPaused
+    -- ^ For calls to end user actions when the contract is paused.
   deriving stock (Eq, Generic)
+
+instance Buildable Parameter where
+  build = \case
+    Transfer (arg #from -> from, arg #to -> to, arg #value -> value) ->
+      "Transfer from " +| from |+ " to " +| to |+ ", value = " +| value |+ ""
+    Approve (arg #spender -> spender, arg #value -> value) ->
+      "Approve for " +| spender |+ ", value = " +| value |+ ""
+    GetAllowance (View (arg #owner -> owner, arg #spender -> spender) _) ->
+      "Get allowance for " +| owner |+ " from " +| spender |+ ""
+    GetBalance (View addr _) ->
+      "Get balance for " +| addr |+ ""
+    GetTotalSupply _ ->
+      "Get total supply"
+    GetTotalMinted _ ->
+      "Get total minted"
+    GetTotalBurned _ ->
+      "Get total burned"
+    SetAdministrator addr ->
+      "Set administrator to " +| addr |+ ""
+    GetAdministrator _ ->
+      "Get administrator"
+    Mint (arg #to -> to, arg #value -> value) ->
+      "Mint to " +| to |+ ", value = " +| value |+ ""
+    MintForMigration (arg #to -> to, arg #value -> value) ->
+      "MintForMigration to " +| to |+ ", value = " +| value |+ ""
+    Burn (arg #value -> value) ->
+      "Burn, value = " +| value |+ ""
+    AddOperator (arg #operator -> operator) ->
+      "Add operator " +| operator |+ ""
+    RemoveOperator (arg #operator -> operator) ->
+      "Remove operator " +| operator |+ ""
+    SetRedeemAddress (arg #redeem -> redeem) ->
+      "Set redeem address to " +| redeem |+ ""
+    Pause _ ->
+      "Pause"
+    Unpause _ ->
+      "Unpause"
+    TransferOwnership (arg #newOwner -> newOwner) ->
+      "Transfer ownership to " +| newOwner |+ ""
+    AcceptOwnership _ ->
+      "Accept ownership"
+    StartMigrateTo (arg #migrationManager -> migrationMangerAddress) ->
+      "Start migrate to " +| migrationMangerAddress |+ ""
+    StartMigrateFrom (arg #migrationManager -> migrationAgent) ->
+      "Start migrate from " +| migrationAgent |+ ""
+    Migrate _ ->
+      "Migrate"
 
 deriveCustomError ''Error
 
@@ -98,9 +201,9 @@ mkStorage adminAddress redeem balances operators = mkStorage' balances $
   , totalMinted = sum balances
   , newOwner = Nothing
   , operators = operators
-  , migrateFrom = Nothing
-  , migrateTo = Nothing
   , redeemAddress = redeem
   , code = [mt|ZBTC|]
   , tokenname = [mt|TZBTC|]
+  , migrationManagerOut = Nothing
+  , migrationManagerIn = Nothing
   }

--- a/test.bats
+++ b/test.bats
@@ -14,15 +14,13 @@
 @test "invoking tzbtc 'mint' command" {
   result="$(stack exec -- tzbtc mint\
           --to "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" --value 100)"
-  echo $result;
-  [ "$result" == '(Left (Right (Right (Right (Right (Pair "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" 100))))))' ]
+  [ "$result" == '(Left (Right (Right (Right (Left (Pair "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" 100))))))' ]
 
 }
 
 @test "invoking tzbtc 'burn' command" {
   result="$(stack exec -- tzbtc burn --value 100)"
-  echo $result;
-  [ "$result" == '(Right (Left (Left (Left 100))))' ]
+  [ "$result" == '(Left (Right (Right (Right (Right 100)))))' ]
 }
 
 @test "invoking tzbtc 'transfer' command" {
@@ -44,50 +42,44 @@
   result="$(stack exec -- tzbtc getBalance\
     --address "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"\
     --callback "KT1SyriCZ2kDyEMJ6BtQecGkFqVciQcfWj46")"
-  echo $result;
   [ "$result" == '(Left (Left (Right (Right (Left (Pair "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV" "KT1SyriCZ2kDyEMJ6BtQecGkFqVciQcfWj46"))))))' ]
 }
 
 @test "invoking tzbtc 'addOperator' command" {
   result="$(stack exec -- tzbtc addOperator\
     --operator "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV")"
-  echo $result;
-  [ "$result" == '(Right (Left (Left (Right "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"))))' ]
+  [ "$result" == '(Right (Left (Left (Left "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"))))' ]
 }
 
 @test "invoking tzbtc 'removeOperator' command" {
   result="$(stack exec -- tzbtc removeOperator\
     --operator "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV")"
-  echo $result;
-  [ "$result" == '(Right (Left (Right (Left "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"))))' ]
+  [ "$result" == '(Right (Left (Left (Right "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"))))' ]
 }
 
 @test "invoking tzbtc 'pause' command" {
   result="$(stack exec -- tzbtc pause)"
-  echo $result;
-  [ "$result" == '(Right (Left (Right (Right (Right Unit)))))' ]
+  [ "$result" == '(Right (Left (Right (Right (Left Unit)))))' ]
 }
 
 @test "invoking tzbtc 'unpause' command" {
   result="$(stack exec -- tzbtc unpause)"
-  echo $result;
-  [ "$result" == '(Right (Right (Left (Left Unit))))' ]
+  [ "$result" == '(Right (Left (Right (Right (Right Unit)))))' ]
 }
 
 @test "invoking tzbtc 'setRedeemAddress' command" {
   result="$(stack exec -- tzbtc setRedeemAddress "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV")"
-  echo $result;
-  [ "$result" == '(Right (Left (Right (Right (Left "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV")))))' ]
+  [ "$result" == '(Right (Left (Right (Left "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"))))' ]
 }
 
 @test "invoking tzbtc 'startMigrateFrom' command" {
   result="$(stack exec -- tzbtc startMigrateFrom "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV")"
-  [ "$result" == '(Right (Right (Right (Right (Left "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV")))))' ]
+  [ "$result" == '(Right (Right (Right (Left "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"))))' ]
 }
 
 @test "invoking tzbtc 'startMigrateTo' command" {
   result="$(stack exec -- tzbtc startMigrateTo "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV")"
-  [ "$result" == '(Right (Right (Right (Left "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"))))' ]
+  [ "$result" == '(Right (Right (Left (Right (Right "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV")))))' ]
 }
 
 @test "invoking tzbtc 'migrate' command" {
@@ -103,12 +95,20 @@
   stack exec -- tzbtc printContract --oneline
 }
 
-@test "invoking tzbts 'printInitialStorage'" {
-  result="$(stack exec -- tzbtc printInitialStorage tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV)"
-  [ "$result" == '(Pair { } (Pair (Pair (Pair "tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx" (Pair False 0)) (Pair 0 (Pair 0 None))) (Pair (Pair { } (Pair None None)) (Pair "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV" (Pair "ZBTC" "TZBTC")))))' ]
+@test "invoking tzbtc 'printAgentContract' command" {
+  stack exec -- tzbtc printAgentContract
 }
 
-@test "invoking 'parseContractParameter' to parse burn parameter" {
+@test "invoking tzbtc 'printAgentContract' command with --oneline flag" {
+  stack exec -- tzbtc printAgentContract --oneline
+}
+
+@test "invoking tzbts 'printInitialStorage' command" {
+  result="$(stack exec -- tzbtc printInitialStorage tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV)"
+  [ "$result" == '(Pair { } (Pair (Pair (Pair "tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx" (Pair False 0)) (Pair 0 (Pair 0 None))) (Pair (Pair { } (Pair "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV" "ZBTC")) (Pair "TZBTC" (Pair None None)))))' ]
+}
+
+@test "invoking 'parseContractParameter' command to parse burn parameter" {
   raw_parameter="$(stack exec -- tzbtc burn --value 100500)"
   exec_command="stack exec -- tzbtc parseContractParameter '${raw_parameter}'"
   result=$(eval $exec_command)

--- a/test/Test/TZBTC.hs
+++ b/test/Test/TZBTC.hs
@@ -14,6 +14,8 @@ module Test.TZBTC
   , test_pause
   , test_unpause_
   , test_bookkeeping
+  , test_migration
+  , test_migrationManager
   ) where
 
 import Fmt (pretty)
@@ -21,19 +23,22 @@ import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (Assertion, assertEqual, assertBool, assertFailure, testCase)
 import qualified Data.Map as Map
 import Data.Set
+import Data.Singletons (SingI(..))
 import qualified Data.Set as Set
 import Named (arg)
 
 import Lorentz
 import Lorentz.Contracts.Consumer
 import Lorentz.Contracts.TZBTC
+import qualified Lorentz.Contracts.TZBTC.Agent as Agent
 import Lorentz.Contracts.TZBTC.Types
 import Lorentz.Test.Integrational
 import Michelson.Interpret (ContractEnv(..), MichelsonFailed(..))
 import Michelson.Test
   ( ContractPropValidator, contractProp, dummyContractEnv)
 import Michelson.Text (mt)
-import Michelson.Typed (Instr, ToTs, Value, Value'(..))
+import Michelson.Typed (Instr, InstrWrapC, AppendCtorField, GetCtorField, ToTs, Value, Value'(..))
+import Michelson.Typed.Scope (checkOpPresence, OpPresence(..))
 import Util.Named
 
 lContract :: Instr (ToTs '[(Parameter, Storage)]) (ToTs (ContractOut Storage))
@@ -44,9 +49,6 @@ newOperatorAddress = genesisAddress1
 
 adminAddress :: Address
 adminAddress = genesisAddress3
-
-badAdminAddress :: Address
-badAdminAddress = genesisAddress5
 
 redeemAddress_ :: Address
 redeemAddress_ = adminAddress
@@ -59,6 +61,9 @@ contractAddress = genesisAddress4
 
 alice :: Address
 alice = genesisAddress6
+
+bob :: Address
+bob = genesisAddress5
 
 initialSupply :: Natural
 initialSupply = 500
@@ -96,27 +101,23 @@ assertFailureMessage res msg tstMsg = case res of
 test_adminCheck :: TestTree
 test_adminCheck = testGroup "TZBTC contract admin check test"
   [ testCase "Fails with `SenderNotAdmin` if sender is not administrator for `addOperator` call" $
-      contractPropWithSender badAdminAddress validate'
+      contractPropWithSender bob validate'
         (AddOperator (#operator .! newOperatorAddress)) storage
   , testCase
       "Fails with `SenderNotAdmin` if sender is not administrator for `removeOperator` call" $
-      contractPropWithSender badAdminAddress validate'
+      contractPropWithSender bob validate'
         (RemoveOperator (#operator .! newOperatorAddress)) storage
   , testCase
       "Fails with `SenderNotAdmin` if sender is not administrator for `startMigrateFrom` call" $
-      contractPropWithSender badAdminAddress validate'
-        (StartMigrateFrom (#migratefrom .! contractAddress)) storage
-  , testCase
-      "Fails with `SenderNotAdmin` if sender is not administrator for `startMigrateTo` call" $
-      contractPropWithSender badAdminAddress validate'
-        (StartMigrateTo (#migrateto .! contractAddress)) storage
+      contractPropWithSender bob validate'
+        (StartMigrateFrom (#migrationManager .! (ContractAddr contractAddress))) storage
   , testCase
       "Fails with `SenderNotAdmin` if sender is not administrator for `transferOwnership` call" $
-      contractPropWithSender badAdminAddress validate'
-        (TransferOwnership (#newowner .! adminAddress)) storage
+      contractPropWithSender bob validate'
+        (TransferOwnership (#newOwner .! adminAddress)) storage
   , testCase
       "Fails with `SenderNotAdmin` if sender is not administrator for `setRedeemAddress` call" $
-      contractPropWithSender badAdminAddress validate'
+      contractPropWithSender bob validate'
         (SetRedeemAddress (#redeem .! redeemAddress_)) storage
   ]
   where
@@ -152,7 +153,9 @@ test_removeOperator = testGroup "TZBTC contract `removeOperator` test"
   ]
   where
     operatorToRemove = replaceAddress
-    storageWithOperator = mkStorage adminAddress redeemAddress_ mempty (Set.fromList [operatorToRemove])
+    storageWithOperator =
+      mkStorage adminAddress redeemAddress_
+        mempty (Set.fromList [operatorToRemove])
     validateRemove :: ContractPropValidator (ToT Storage) Assertion
     validateRemove (res, _) =
       case res of
@@ -185,7 +188,7 @@ test_transferOwnership = testGroup "TZBTC contract `transferOwnership` test"
   [ testCase
       "Call to `transferOwnership` updates `newOwner`" $
       contractPropWithSender adminAddress
-        validate_ (TransferOwnership (#newowner .! newOwnerAddress)) storage
+        validate_ (TransferOwnership (#newOwner .! newOwnerAddress)) storage
   ]
   where
     newOwnerAddress = replaceAddress
@@ -206,17 +209,21 @@ test_acceptOwnership = testGroup "TZBTC contract `acceptOwnership` test"
       contractPropWithSender newOwnerAddress
         validateNotInTransfer (AcceptOwnership ()) storage
   , testCase
-      "Call to `acceptOwnership` fails for bad caller" $
+      "Call to `acceptOwnership` fails for random caller" $
       contractPropWithSender badSenderAddress
         validateBadSender (AcceptOwnership ()) storageInTranferOwnership
   , testCase
-      "Call to `acceptOwnership` updates admin with address of new owner" $
+      "Call to `acceptOwnership` fails for current admin" $
+      contractPropWithSender adminAddress
+        validateBadSender (AcceptOwnership ()) storageInTranferOwnership
+  , testCase
+      "Call to `acceptOwnership` updates admin with address of new owner and resets `newOwner` field" $
       contractPropWithSender newOwnerAddress
         validateGoodOwner (AcceptOwnership ()) storageInTranferOwnership
   ]
   where
     newOwnerAddress = replaceAddress
-    badSenderAddress = genesisAddress1
+    badSenderAddress = bob
     storageInTranferOwnership = let
       f = fields storage
       in storage { fields = f { newOwner = Just newOwnerAddress } }
@@ -250,11 +257,16 @@ test_acceptOwnership = testGroup "TZBTC contract `acceptOwnership` test"
 test_burn :: TestTree
 test_burn = testGroup "TZBTC contract `burn` test"
   [ testCase
-      "Call to `burn` gets denied with `SenderIsNotOperator`" $
+      "Call to `burn` from admin gets denied with `SenderIsNotOperator`" $
       contractPropWithSender adminAddress
         validateFail_ (Burn (#value .! 100)) storageWithOperator
   , testCase
-      "Call to `burn` burns from `redeemAddress` and update `totalBurned` \
+      "Call to `burn` from random address gets denied with `SenderIsNotOperator`" $
+      contractPropWithSender bob
+        validateFail_ (Burn (#value .! 100)) storageWithOperator
+
+  , testCase
+      "Call to `burn` from operator, burns from `redeemAddress` and update `totalBurned` \
       \ and `totalSupply` fields correctly" $
       contractPropWithSender newOperatorAddress
         validate_ (Burn (#value .! 100)) storageWithOperator
@@ -262,7 +274,8 @@ test_burn = testGroup "TZBTC contract `burn` test"
   where
     storageWithOperator =
       mkStorage adminAddress redeemAddress_
-        (Map.fromList [(redeemAddress_, initialSupply)]) (Set.fromList [newOperatorAddress])
+        (Map.fromList [(redeemAddress_, initialSupply)])
+          (Set.fromList [newOperatorAddress])
     validateFail_ :: ContractPropValidator (ToT Storage) Assertion
     validateFail_ (res, _) =
       assertFailureMessage
@@ -280,7 +293,6 @@ test_burn = testGroup "TZBTC contract `burn` test"
              (((arg #balance) . fst)
                 <$> (Map.lookup redeemAddress_ $ unBigMap $
                   ledger $ (fromVal rstorage :: Storage)))
-          --  Assert the totalBurned field in storage is updated correctly.
           assertEqual
             "Contract's `burn` operation did not update `totalBurned` field correctly."
              100
@@ -293,8 +305,12 @@ test_burn = testGroup "TZBTC contract `burn` test"
 test_mint :: TestTree
 test_mint = testGroup "TZBTC contract `mint` test"
   [ testCase
-      "Call to `mint` gets denied with `SenderIsNotOperator`" $
+      "Call to `mint` from admin gets denied with `SenderIsNotOperator`" $
       contractPropWithSender adminAddress
+        validateFail_ (Burn (#value .! 100)) storageWithOperator
+  , testCase
+      "Call to `mint` from random address gets denied with `SenderIsNotOperator`" $
+      contractPropWithSender bob
         validateFail_ (Burn (#value .! 100)) storageWithOperator
   , testCase
       "Call to `mint` adds value to `to` parameter in input and update `totalMinted` \
@@ -305,7 +321,8 @@ test_mint = testGroup "TZBTC contract `mint` test"
   where
     storageWithOperator =
       mkStorage adminAddress redeemAddress_
-        (Map.fromList [(redeemAddress_, initialSupply)]) (Set.fromList [newOperatorAddress])
+        (Map.fromList [(redeemAddress_, initialSupply)])
+        (Set.fromList [newOperatorAddress])
     validateFail_ :: ContractPropValidator (ToT Storage) Assertion
     validateFail_ (res, _) =
       assertFailureMessage
@@ -323,7 +340,6 @@ test_mint = testGroup "TZBTC contract `mint` test"
              (((arg #balance) . fst)
                 <$> (Map.lookup alice $ unBigMap $
                   ledger $ (fromVal rstorage :: Storage)))
-          --  Assert the totalBurned field in storage is updated correctly.
           assertEqual
             "Contract's `mint` operation did not update `totalMinted` field correctly."
              700
@@ -336,8 +352,12 @@ test_mint = testGroup "TZBTC contract `mint` test"
 test_pause :: TestTree
 test_pause = testGroup "TZBTC contract `pause` permission test"
   [ testCase
-      "Call to `pause` gets denied with `SenderIsNotOperator`" $
+      "Call to `pause` from admin gets denied with `SenderIsNotOperator`" $
       contractPropWithSender adminAddress
+        validateFail_ (Pause ()) storageWithOperator
+  , testCase
+      "Call to `pause` from random address gets denied with `SenderIsNotOperator`" $
+      contractPropWithSender bob
         validateFail_ (Pause ()) storageWithOperator
   , testCase
       "Call to `pause` as operator is allowed" $
@@ -347,7 +367,8 @@ test_pause = testGroup "TZBTC contract `pause` permission test"
   where
     storageWithOperator =
       mkStorage adminAddress redeemAddress_
-        (Map.fromList [(redeemAddress_, initialSupply)]) (Set.fromList [newOperatorAddress])
+        (Map.fromList [(redeemAddress_, initialSupply)])
+        (Set.fromList [newOperatorAddress])
     validateFail_ :: ContractPropValidator (ToT Storage) Assertion
     validateFail_ (res, _) =
       assertFailureMessage
@@ -371,6 +392,10 @@ test_unpause_ = testGroup "TZBTC contract `unpause` permission test"
       contractPropWithSender newOperatorAddress
         validateFail_ (Unpause ()) storageWithOperator
   , testCase
+      "Call to `unpause` from random address gets denied with `SenderIsNotAdmin`" $
+      contractPropWithSender bob
+        validateFail_ (Unpause ()) storageWithOperator
+  , testCase
       "Call to `unpause` as admin is allowed" $
       contractPropWithSender adminAddress
         validate_ (Unpause ()) storageWithOperator
@@ -378,7 +403,8 @@ test_unpause_ = testGroup "TZBTC contract `unpause` permission test"
   where
     storageWithOperator =
       mkStorage adminAddress redeemAddress_
-        (Map.fromList [(redeemAddress_, initialSupply)]) (Set.fromList [newOperatorAddress])
+        (Map.fromList [(redeemAddress_, initialSupply)])
+        (Set.fromList [newOperatorAddress])
     validateFail_ :: ContractPropValidator (ToT Storage) Assertion
     validateFail_ (res, _) =
       assertFailureMessage
@@ -420,3 +446,236 @@ test_bookkeeping = testGroup "TZBTC contract bookkeeping views test"
     st :: Storage
     st = mkStorage adminAddress redeemAddress_
         (Map.fromList [(redeemAddress_, initialSupply)]) (Set.fromList [newOperatorAddress])
+
+-- Migration tests
+
+storageV1 :: Storage
+storageV1 =
+  mkStorage adminAddress redeemAddress_
+    (Map.fromList [(alice, initialSupply)])
+          (Set.fromList [newOperatorAddress])
+
+storageV2 :: Storage
+storageV2 =
+  mkStorage adminAddress redeemAddress_ mempty mempty
+
+originateV1 :: IntegrationalScenarioM (ContractAddr Parameter)
+originateV1 =
+  lOriginate tzbtcContract "UserUpgradeable V1" storageV1 (toMutez 1000)
+
+originateV2 :: IntegrationalScenarioM (ContractAddr Parameter)
+originateV2 =
+  lOriginate tzbtcContract "UserUpgradeable V2" storageV2 (toMutez 1000)
+
+originateAgent
+  :: forall v2.
+  ( InstrWrapC v2 "cMintForMigration"
+  , AppendCtorField (GetCtorField v2 "cMintForMigration") '[] ~ '[("to" :! Address, "value" :! Natural)]
+  , KnownValue v2, NoOperation v2, NoBigMap v2)
+  => Address
+  -> ContractAddr v2
+  -> IntegrationalScenarioM (ContractAddr Agent.Parameter)
+originateAgent oldContract newContract =
+  case checkOpPresence (sing @(ToT v2)) of
+    OpAbsent ->
+      lOriginate (Agent.agentContract @v2) "Migration Agent" agentStorage (toMutez 1000)
+    OpPresent ->
+      error "Cannot originate contract with operations in parameter"
+    where
+      agentStorage = Agent.StorageFields
+        { oldVersion = oldContract
+        , newVersion = newContract
+        }
+
+test_migration :: TestTree
+test_migration = testGroup "TZBTC contract migration tests"
+  [ testCase
+      "call `migrate` to unprepared contract is denied" $
+        integrationalTestExpectation $ do
+          v1 <- originateV1
+          withSender alice $ lCall v1 (Migrate ())
+          validate . Left $
+            lExpectError (== MigrationNotEnabled)
+  , testCase
+      "call to `migrate` from an empty accounts address fails" $
+        integrationalTestExpectation $ do
+          v1 <- originateV1
+          v2 <- originateV2
+          agent <- originateAgent (unContractAddress v1) v2
+          withSender newOperatorAddress $ lCall v1 (Pause ())
+          withSender adminAddress $ lCall v1 (StartMigrateTo (#migrationManager .! agent) )
+          withSender adminAddress $ lCall v1 (Unpause ())
+          withSender bob $ lCall v1 (Migrate ())
+          validate . Left $
+            lExpectError (== NoBalanceToMigrate)
+ , testCase
+     "call `startMigrateTo` to from non admin address fails" $
+       integrationalTestExpectation $ do
+         v1 <- originateV1
+         v2 <- originateV2
+         agent <- originateAgent (unContractAddress v1) v2
+         withSender newOperatorAddress $ lCall v1 (Pause ())
+         withSender bob $ lCall v1 (StartMigrateTo $ (#migrationManager .! agent))
+         withSender adminAddress $ lCall v1 (Unpause ())
+         validate . Left $
+           lExpectError (== SenderIsNotAdmin)
+ , testCase
+     "call `startMigrateFrom` to from non admin address fails" $
+       integrationalTestExpectation $ do
+         v1 <- originateV1
+         v2 <- originateV2
+         agent <- originateAgent (unContractAddress v1) v2
+         withSender bob $ lCall v2 (StartMigrateFrom $ (#migrationManager .! agent))
+         validate . Left $
+           lExpectError (== SenderIsNotAdmin)
+ , testCase
+     "call `startMigrateTo` from admin saves the address of migration manager proxy" $
+       integrationalTestExpectation $ do
+         v1 <- originateV1
+         v2 <- originateV2
+         agent <- originateAgent (unContractAddress v1) v2
+         withSender newOperatorAddress $ lCall v1 (Pause ())
+         withSender adminAddress $ lCall v1 (StartMigrateTo $ (#migrationManager .! agent))
+         withSender adminAddress $ lCall v1 (Unpause ())
+         validate . Right $
+           lExpectStorageConst v1 $ let
+            oldFields = fields storageV1
+            in storageV1
+              { fields = oldFields { migrationManagerOut = Just agent }}
+ , testCase
+     "call `startMigrateTo` to unpaused contract is denied with `ContractIsNotPaused` error" $
+       integrationalTestExpectation $ do
+         v1 <- originateV1
+         v2 <- originateV2
+         agent <- originateAgent (unContractAddress v1) v2
+         withSender adminAddress $ lCall v1 (StartMigrateTo $ (#migrationManager .! agent))
+         validate . Left $
+           lExpectError (== ContractIsNotPaused)
+ , testCase
+     "multple calls `startMigrateTo` from admin stores the address of the last call" $
+       integrationalTestExpectation $ do
+         v1 <- originateV1
+         v2 <- originateV2
+         agent <- originateAgent (unContractAddress v2) v1
+         agent2 <- originateAgent (unContractAddress v1) v2
+         withSender newOperatorAddress $ lCall v1 (Pause ())
+         withSender adminAddress $ lCall v1 (StartMigrateTo $ (#migrationManager .! agent))
+         withSender adminAddress $ lCall v1 (StartMigrateTo $ (#migrationManager .! agent2))
+         withSender adminAddress $ lCall v1 (Unpause ())
+         validate . Right $
+           lExpectStorageConst v1 $ let
+            oldFields = fields storageV1
+            in storageV1
+              { fields = oldFields { migrationManagerOut = Just agent2 }}
+ , testCase
+     "call `startMigrateFrom` from admin saves the address of migration agent proxy" $
+       integrationalTestExpectation $ do
+         v1 <- originateV1
+         v2 <- originateV2
+         agent <- originateAgent (unContractAddress v1) v2
+         withSender adminAddress $ lCall v2 (StartMigrateFrom $ (#migrationManager .! agent))
+         validate . Right $
+           lExpectStorageConst v2 $ let
+            oldFields = fields storageV2
+            in storageV2
+              { fields = oldFields { migrationManagerIn = Just agent }}
+ , testCase
+     "multiple calls to `startMigrateFrom` from admin saves the address from the last call" $
+       integrationalTestExpectation $ do
+         v1 <- originateV1
+         v2 <- originateV2
+         agent <- originateAgent (unContractAddress v2) v1
+         agent2 <- originateAgent (unContractAddress v1) v2
+         withSender adminAddress $ lCall v2 (StartMigrateFrom $ (#migrationManager .! agent))
+         withSender adminAddress $ lCall v2 (StartMigrateFrom $ (#migrationManager .! agent2))
+         validate . Right $
+           lExpectStorageConst v2 $ let
+            oldFields = fields storageV2
+            in storageV2
+              { fields = oldFields { migrationManagerIn = Just agent2 }}
+ , testCase
+     "call `mintForMigration` from random address to new contract is denied" $
+       integrationalTestExpectation $ do
+         v1 <- originateV1
+         v2 <- originateV2
+         agent <- originateAgent (unContractAddress v1) v2
+         withSender adminAddress $ lCall v2 (StartMigrateFrom $ (#migrationManager .! agent))
+         withSender bob $ lCall v2 (MintForMigration $ (#to .! alice, #value .! 100))
+         validate . Left $
+           lExpectError (== SenderIsNotAgent)
+
+ , testCase
+     "call `mintForMigration` from agent address to new contract mints tokens" $
+       integrationalTestExpectation $ do
+         v1 <- originateV1
+         v2 <- originateV2
+         agent <- originateAgent (unContractAddress v1) v2
+         withSender adminAddress $ lCall v2 (StartMigrateFrom $ (#migrationManager .! agent))
+         withSender (unContractAddress agent) $ lCall v2 (MintForMigration $ (#to .! alice, #value .! 250))
+         consumer <- lOriginateEmpty contractConsumer "consumer"
+         lCall v2 $ GetBalance (View alice consumer)
+         validate . Right $
+           lExpectViewConsumerStorage consumer [250]
+ , testCase
+     "call `mintForMigration` to contract that does not have migration agent set is denied" $
+       integrationalTestExpectation $ do
+         v2 <- originateV2
+         withSender bob $ lCall v2 (MintForMigration $ (#to .! alice, #value .! 100))
+         validate . Left $
+           lExpectError (== MigrationNotEnabled)
+  ]
+
+test_migrationManager :: TestTree
+test_migrationManager = testGroup "TZBTC migration manager tests"
+  [ testCase
+      "migration manager stores addesses of both old and new contracts" $
+        integrationalTestExpectation $ do
+          v1 <- originateV1
+          v2 <- originateV2
+          agent <- originateAgent (unContractAddress v1) v2
+          validate . Right $
+            lExpectStorageConst agent $
+              Agent.StorageFields
+                { oldVersion = unContractAddress v1
+                , newVersion = v2
+                }
+  , testCase
+      "calling migration manager from random address is denied" $
+        integrationalTestExpectation $ do
+          v1 <- originateV1
+          v2 <- originateV2
+          agent <- originateAgent (unContractAddress v1) v2
+          withSender bob $ lCall agent (alice, 100)
+          validate . Left $
+            lExpectError (== Agent.MigrationBadOrigin)
+  , testCase
+      "calling migrate on old version burns tokens in old version and mint them in new" $
+        integrationalTestExpectation $ do
+          v1 <- originateV1
+          v2 <- originateV2
+          agent <- originateAgent (unContractAddress v1) v2
+          consumer <- lOriginateEmpty contractConsumer "consumer"
+          withSender newOperatorAddress $ lCall v1 (Pause ())
+          withSender adminAddress $ lCall v1 (StartMigrateTo $ (#migrationManager .! agent))
+          withSender adminAddress $ lCall v2 (StartMigrateFrom $ (#migrationManager .! agent))
+          withSender adminAddress $ lCall v1 (Unpause ())
+          lCall v1 $ GetBalance (View alice consumer)
+          lCall v2 $ GetBalance (View alice consumer)
+          withSender alice $ lCall v1 (Migrate ())
+          lCall v1 $ GetBalance (View alice consumer)
+          lCall v2 $ GetBalance (View alice consumer)
+          validate . Right $
+            lExpectViewConsumerStorage consumer [500, 0, 0, 500]
+  , testCase
+      "calling migrate on paused contract fails with `ContractIsPaused` error" $
+        integrationalTestExpectation $ do
+          v1 <- originateV1
+          v2 <- originateV2
+          agent <- originateAgent (unContractAddress v1) v2
+          withSender newOperatorAddress $ lCall v1 (Pause ())
+          withSender adminAddress $ lCall v1 (StartMigrateTo $ (#migrationManager .! agent))
+          withSender adminAddress $ lCall v2 (StartMigrateFrom $ (#migrationManager .! agent))
+          withSender alice $ lCall v1 (Migrate ())
+          validate . Left $
+            lExpectError (== ContractIsPaused)
+  ]


### PR DESCRIPTION
<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description
Problem: Make possible the migration of a contract to a newer version.

Solution: Implement the migration using the proxy method as described
in https://issues.serokell.io/issue/TM-295, thus this commit adds the
following entry points (with their inputs)

    StartMigrateTo ("migrationManager" :! MigrationManager)
    StartMigrateFrom ("migrationAgent" :! MigrationManager)
    MintForMigration ("to" :! Address, "value" :! Natural)
    Migrate ()

### startMigrateTo

This entry point is only callable by admin. This input
to this entry point is `("migrationManager" :! MigrationManager)`, which
is just the address of a proxy contract of type
`ContractAddr (Address, Natural)`, that will handle the conversion and
minting of tokens in the new contract. This address is  stored in contract's
storage, in the `migrationManagerOut` field. Admin can call this entry
point as many times as required, and consecutive calls just overwrites
previous value with the new one. This entry point can fail with
`SenderIsNotAdmin` error.

### startMigrateFrom

This entry point is only callable by admin. This input
to this entry point is `("migrationAgent" :! MigrationManager)`, which
is just the address of a proxy contract of type
`ContractAddr (Address, Natural)` that will be talking to this contract
to request tokens to be minted here on behalf of accounts in the old contract.
The contract stores this address in the `migrationManagerIn` field. This entry
point is also callable multiple times and each call just overwrites the
value from the earlier call with new value. This entry point can fail with
`SenderIsNotAdmin` error.

### mintForMigration

This entry point is only callable by the address that
is stored in `migrationManagerIn` field.  This mints tokens in the new
contract on behalf of accounts in the old. This first check if the `MigrationManagerIn` field
is set, and if it is not set, fails with `MigrationNotEnabled` error. If it is available, it checks if the value it contains is the same as the sender's address. If it is not then the contract fails with `SenderIsNotAgent` error. If both checks pass, then the contract calls the `mint` procedure to mint
tokens for the account along with the associated bookkeeping. 

### migrate

This entry point migrate callers tokens (all of them) in this
contract to the new contract. This

1. Gets the balance in the account for the sender.
2. If there is no balance, fails with `NoBalanceToMigrate` error.
3. Burn all their tokens in this contract.
3. Get the address of the migration manager from storage. If there is no
migration manager set, fails with `MigrationNotEnabled` error.
4. Call the migration manager with the address of the sender, and their
balance.

This is an end user call that is only possible when the contract is in a running (unpaused) state.

This PR also adds a new module `Lorentz.Contracts.Agent` that encapsulates
the functionality of a migration manger and can work with any contract
as long as it has a `MintForMigration` constructor with a single field
of type `("to" :! Address, "value" :! Natural)`.

So the process of migration is as follows.

1. Admin deploys the migration agent passing the addresses of the old contract and the new.
2. Admin/Operator pauses the old contract.
3. Admin calls Contract1's `startMigrateTo` entry point passing the address of the migration agent.
4. Admin calls Contract2's `startMigrateFrom` entry point passing the address of the migration agent.
5. Admin unpauses Contract1.

Tests: Tests that checks all the intended behavior is included.

Dependencies: TM-299, TM-298, TM-296
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-14

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
