### PR TITLE
[TBTC-20] Add missing fields to contract storage

### DIFF
--- a/src/Lorentz/Contracts/TZBTC/Types.hs
+++ b/src/Lorentz/Contracts/TZBTC/Types.hs
@@ -55,7 +55,9 @@ data StorageFields = StorageFields
   , migrateFrom :: Maybe Address
   , migrateTo   :: Maybe Address
   , redeemAddress :: Address
-  } deriving stock Generic -- @TODO Is TokenName required here?
+  , code :: MText
+  , tokenname :: MText
+  } deriving stock Generic
     deriving anyclass IsoValue
 
 data Error
@@ -99,4 +101,6 @@ mkStorage adminAddress redeem balances operators = mkStorage' balances $
   , migrateFrom = Nothing
   , migrateTo = Nothing
   , redeemAddress = redeem
+  , code = [mt|ZBTC|]
+  , tokenname = [mt|TZBTC|]
   }

--- a/test.bats
+++ b/test.bats
@@ -97,7 +97,7 @@
 
 @test "invoking tzbts 'printInitialStorage'" {
   result="$(stack exec -- tzbtc printInitialStorage tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV)"
-  [ "$result" == '(Pair { } (Pair (Pair (Pair "tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx" False) (Pair 0 (Pair 0 0))) (Pair (Pair None { }) (Pair None (Pair None "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV")))))' ]
+  [ "$result" == '(Pair { } (Pair (Pair (Pair "tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx" (Pair False 0)) (Pair 0 (Pair 0 None))) (Pair (Pair { } (Pair None None)) (Pair "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV" (Pair "ZBTC" "TZBTC")))))' ]
 }
 
 @test "invoking 'parseContractParameter' to parse burn parameter" {


### PR DESCRIPTION
Problem: Contract storage does not have tokenname and code fields

Solution: Add the `tokenname` and `code` fields to storage and populate
them while initializing the contract. Right now `tokenname` is set to
`TZBTC` and code to `ZBTC`.

<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-20

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
