### PR TITLE
[TBTC-25] Replace `contract p` with `address` in storage

### DIFF
--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -274,11 +274,11 @@ transferOwnershipParamsParser = #newOwner
 
 startMigrateFromParamsParser :: Opt.Parser StartMigrateFromParams
 startMigrateFromParamsParser = #migrationManager <.!>
-  (ContractAddr <$> addressArgument "Source contract address")
+  (addressArgument "Source contract address")
 
 startMigrateToParamsParser :: Opt.Parser StartMigrateToParams
 startMigrateToParamsParser = #migrationManager <.!>
-  (ContractAddr <$> addressArgument "Manager contract address")
+  (addressArgument "Manager contract address")
 
 -- Maybe add default value and make sure it will be shown in help message.
 maybeAddDefault :: Opt.HasValue f => (a -> String) -> Maybe a -> Opt.Mod f a

--- a/src/Lorentz/Contracts/TZBTC/Impl.hs
+++ b/src/Lorentz/Contracts/TZBTC/Impl.hs
@@ -300,7 +300,7 @@ mintForMigration = do
   where
     ensureMigrationAgent = do
       stGetField #migrationManagerIn
-      ifSome (do address; sender # eq) (failCustom_ #migrationNotEnabled)
+      ifSome (do sender # eq) (failCustom_ #migrationNotEnabled)
       if_ nop $ failCustom_ #senderIsNotAgent
 
 -- | This entry point just fetches the migration manager from storage
@@ -350,10 +350,15 @@ migrate = do
         stGetField #migrationManagerOut
         if IsSome then do
           stackType @'[MigrationManager, store]
-          nop
+          contract
+          stackType @'[Maybe MigrationManagerCType, store]
+          if IsSome then do
+            nop
+          else
+            failCustom_ #illTypedMigrationManager
         else
           failCustom_ #migrationNotEnabled
-      stackType @'[Natural, MigrationManager, store]
+      stackType @'[Natural, MigrationManagerCType, store]
       sender
       pair
       push (toMutez 0)

--- a/src/Lorentz/Contracts/TZBTC/Types.hs
+++ b/src/Lorentz/Contracts/TZBTC/Types.hs
@@ -17,6 +17,7 @@ module Lorentz.Contracts.TZBTC.Types
   , ManagedLedger.TransferParams
   , MigrateParams
   , MigrationManager
+  , MigrationManagerCType
   , MintForMigrationParams
   , OperatorParams
   , Parameter(..)
@@ -49,7 +50,8 @@ import Michelson.Typed.Extract
 import Michelson.Typed.Sing (Sing(..), fromSingT)
 import Tezos.Address
 
-type MigrationManager = ContractAddr (Address, Natural)
+type MigrationManager = Address
+type MigrationManagerCType = ContractAddr (Address, Natural)
 type BurnParams = ("value" :! Natural)
 type OperatorParams = ("operator" :! Address)
 type TransferViaProxyParams = ("sender" :! Address, ManagedLedger.TransferParams)
@@ -249,6 +251,9 @@ type instance ErrorArg "notAllowedToSetProxy" = ()
 -- | For setProxy entry point if Proxy is set already
 type instance ErrorArg "proxyAlreadySet" = ()
 
+-- | If migration manager was found to be ill-typed
+type instance ErrorArg "illTypedMigrationManager" = ()
+
 instance CustomErrorHasDoc "notInTransferOwnershipMode" where
   customErrDocMdCause =
     "Cannot accept ownership before transfer process has been initiated \
@@ -299,6 +304,10 @@ instance CustomErrorHasDoc "notAllowedToSetProxy" where
 instance CustomErrorHasDoc "proxyAlreadySet" where
   customErrDocMdCause =
     "Cannot set proxy address because it was already set up"
+
+instance CustomErrorHasDoc "illTypedMigrationManager" where
+  customErrDocMdCause =
+    "Type checking on the stored migration manager address failed"
 
 class ToUnpackEnv a where
   toUnpackEnv :: ContractAddr a -> a -> TcOriginatedContracts


### PR DESCRIPTION
Problem: It appears that in Babylon, we will no longer be able to store values
of type `contract` in storage [1]. Right now we have contract values in
storage for migration manager address. We should change this to address
and the code that uses this field accordingly.

Solution: Replace `contract p` values in storage with `address` values
and convert them to contract in the required places in contract code.

Tests: Tests were changed to build with the change.

[1] https://tezos.gitlab.io/mainnet/protocols/005_babylon.html

<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-25

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
