### PR TITLE
[TBTC-33] Make `setupClient` arguments optional

### DIFF
--- a/client/Main.hs
+++ b/client/Main.hs
@@ -30,6 +30,8 @@ main = do
   case dryRunFlag of
     True -> pass
     False -> case cmd of
+      CmdConfig editFlag partialConfig ->
+        runConfigEdit editFlag partialConfig
       CmdSetupClient config -> setupClient config
       CmdMint to' value mbMultisig -> do
         to <- addrOrAliasToAddr to'

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ library:
   dependencies:
     - aeson
     - aeson-casing
+    - aeson-pretty
     - bytestring
     - containers
     - directory

--- a/src/Client/Error.hs
+++ b/src/Client/Error.hs
@@ -18,11 +18,13 @@ import Client.Types
 data TzbtcClientError
   = TzbtcServantError ClientError
   | TzbtcClientConfigError
+  | TzbtcClientConfigFileNotFound FilePath
   | TzbtcRunFailed [RunError]
   | TzbtcUnexpectedRunResult Text
   | TzbtcUnexpectedMultisigStorage MichelsonExpression
   | TzbtcPublicKeyParseError Text CryptoParseError
   | TzbtcUnknownAliasError Text
+  | TzbtcMutlisigConfigUnavailable
 
 instance Buildable TzbtcClientError where
   build (TzbtcServantError err) = case err of
@@ -44,6 +46,12 @@ instance Buildable TzbtcClientError where
 
   build TzbtcClientConfigError =
     "Invalid client configuration. Use 'tzbtc-client setupClient'"
+
+  build (TzbtcClientConfigFileNotFound p) =
+    "Config file was not found at : " +| (build p)
+
+  build TzbtcMutlisigConfigUnavailable =
+    "Multi-sig configuration was not available"
 
   build (TzbtcRunFailed errs) =
     "Transaction run have failed with " +| length errs |+ " errors:\n" +|

--- a/test.bats
+++ b/test.bats
@@ -121,3 +121,19 @@
   result=$(eval $exec_command)
   [ "$result" == 'Burn, value = 100500' ]
 }
+
+@test "invoking tzbtc 'setupClient' command without arguments" {
+  stack exec -- tzbtc-client setupClient
+}
+
+@test "invoking tzbtc 'config' command without arguments" {
+  stack exec -- tzbtc-client config
+}
+
+@test "invoking tzbtc 'config --edit' command with available arguments" {
+  stack exec -- tzbtc-client config --edit --node-url "localhost" --node-port "9900" --contract-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --multisig-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --user-address "tz1VwXeEPw2tkTgDSUUbEb5fe63b24gNEssa" --alias alice --tezos-client /local/bin/tezos-client
+}
+
+@test "invoking tzbtc 'setupClient' command with arguments" {
+  stack exec -- tzbtc-client setupClient --node-url "localhost" --node-port "9900" --contract-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --multisig-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --user-address "tz1VwXeEPw2tkTgDSUUbEb5fe63b24gNEssa" --alias alice --tezos-client /local/bin/tezos-client
+}


### PR DESCRIPTION

<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description
Problem: Right now the command accepts/requires all the configuration
values in one go. But this might not be the best user experience. We can
make all the inputs optional. If an input is absent in the CLI call, we
just create the config file by using a placeholder help text in its
place. And in the CLI output, we just indicate that the config file is
incomplete, as a warning.

Solution: The following changes are part of this PR

1. If the input arguments are absent, write the configuration file with
place holders.

2. If the configuration file exists, already, then will not overwrite
it. Even if the required arguments are present. The user will have to
remove the file manually.

3. Print the config file path after the action.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-33

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
