### PR TITLE
[TBTC-35] Human readable package descriptions.

### DIFF
--- a/client/Main.hs
+++ b/client/Main.hs
@@ -36,7 +36,7 @@ main = do
       pkg <- getPackageFromFile packageFilePath
       case pkg of
         Left err -> putStrLn err
-        Right package -> putStrLn (pretty $ getOpDescription package :: Text)
+        Right package -> putStrLn (pretty package :: Text)
     CmdGetPackageDescription packageFilePath -> do
       pkg <- getPackageFromFile packageFilePath
       case pkg of
@@ -51,8 +51,9 @@ main = do
       pkg <- getPackageFromFile packageFilePath
       case pkg of
         Left err -> putStrLn err
-        Right package ->
-          writePackageToFile (addSignature' package (pk, sign)) packageFilePath
+        Right package -> case addSignature package (pk, sign) of
+          Right signedPackage -> writePackageToFile signedPackage  packageFilePath
+          Left err -> putStrLn err
     CmdCallMultisig packagesFilePaths -> do
       pkgs <- fmap sequence $ mapM getPackageFromFile packagesFilePaths
       case pkgs of

--- a/src/Lorentz/Contracts/TZBTC.hs
+++ b/src/Lorentz/Contracts/TZBTC.hs
@@ -11,6 +11,7 @@ module Lorentz.Contracts.TZBTC
   , Storage
   , StorageFields(..)
   , agentContract
+  , ToUnpackEnv(..)
   , tzbtcContract
   , tzbtcCompileWay
   , tzbtcDoc

--- a/src/Lorentz/Contracts/TZBTC/MultiSig.hs
+++ b/src/Lorentz/Contracts/TZBTC/MultiSig.hs
@@ -44,7 +44,7 @@ data ParamAction
   deriving anyclass IsoValue
 
 type ParamManage
-  = (Natural, [KeyHash])
+  = (Natural, [PublicKey])
 
 type ParamSignatures = [Maybe Signature]
 


### PR DESCRIPTION
Problem : We have package files, but when a user wants to sign the
contents, there is no easy way for them to check what is in it. The
output of `getOpDescription` operation is not helpful as of now.

Solution:
As a solution, store the original parameters ie, (main contract address,
param, counter value) in a packed form inside the multi-sig file.
During the `getOpDescription` call, use the packed params  to obtain the
original parameters. Check that it matches with the bytes that are being
signed. If they match then display it to the user, or else show an
error.

Also, if the bundled original parameters does not match with the included
serialized operation that is being signed, the user will not be allowed to sign the operation.

Sample output of `getOpDescription` after this change:

```
Operation:
------------------
Burn, value = 500

Included Signatures:
--------------------
- Public key: edpkvKTdd6kd4JpMk9fFdmay4zdboWUHRkax5hthJrtDHQ6Gstyn5b
  Signature: edsigtmBWLiTbTYt6wzKDhBm889G4t9mKmkwgt2TXtCKfNZ8TGPALrHfUrqxHkrbrRFyhKG7PQRSzYtam5rreWf6Cyjnwn7WaRL

```

<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-35

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
