### PR TITLE
[TBTC-34] XDG compliant config file path

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -52,6 +52,7 @@ library:
     - aeson
     - aeson-casing
     - singletons
+    - xdg-basedir
 
 executables:
   tzbtc:

--- a/src/Client/IO.hs
+++ b/src/Client/IO.hs
@@ -18,9 +18,10 @@ import Network.HTTP.Client
   (ManagerSettings(..), Request(..), newManager, defaultManagerSettings)
 import Servant.Client
   (BaseUrl(..), ClientError, ClientEnv, Scheme(..), mkClientEnv, runClientM)
-import System.Directory (createDirectoryIfMissing, getAppUserDataDirectory)
+import System.Directory (createDirectoryIfMissing)
 import System.Exit (ExitCode(..))
 import System.Process (readProcessWithExitCode)
+import System.Environment.XDG.BaseDir (getUserConfigDir, getUserConfigFile)
 import Tezos.Json (TezosWord64(..))
 import Tezos.Micheline
   (Expression(..), MichelinePrimAp(..), MichelinePrimitive(..))
@@ -47,8 +48,10 @@ configFile = "config.json"
 
 getFullAppAndConfigPath :: IO (FilePath, FilePath)
 getFullAppAndConfigPath = do
-  appPath <- getAppUserDataDirectory appName
-  return $ (appPath, appPath <> "/" <> configFile)
+  configDir <- getUserConfigDir appName
+  configFile_ <- getUserConfigFile appName configFile
+
+  return $ (configDir, configFile_)
 
 stubSignature :: Signature
 stubSignature = unsafeParseSignature
@@ -252,6 +255,7 @@ setupClient :: ClientConfig -> IO ()
 setupClient config = do
   (appPath, configPath) <- getFullAppAndConfigPath
   createDirectoryIfMissing True appPath
+  putStrLn $ "Config file written to: " ++ configPath
   encodeFile configPath config
 
 runTzbtcContract :: Parameter -> IO ()

--- a/test/Test/TZBTC.hs
+++ b/test/Test/TZBTC.hs
@@ -102,11 +102,14 @@ assertFailureMessage res msg tstMsg = case res of
 
 test_proxyCheck :: TestTree
 test_proxyCheck = testGroup "TZBTC contract proxy endpoints check"
-  [ testCase "Fails with `ProxyIsNotSet` if one of the proxy serving endpoints is called and proxy is not set" $
+  [ testCase
+      "Fails with `ProxyIsNotSet` if one of the proxy serving endpoints is called and \
+      \proxy is not set" $
       contractPropWithSender bob validate'
         (TransferViaProxy (#sender .! bob, (#from .! bob, #to .! alice, #value .! 100))) storage
   , testCase
-      "Fails with `CallerIsNotProxy` if the caller to a proxy endpoint is not known proxy address." $
+      "Fails with `CallerIsNotProxy` if the caller to a proxy endpoint is not \
+      \known proxy address." $
       integrationalTestExpectation $ do
         c <- lOriginate tzbtcContract "TZBTC Contract" storage (toMutez 1000)
         withSender adminAddress $ lCall c (SetProxy contractAddress)
@@ -241,7 +244,8 @@ test_acceptOwnership = testGroup "TZBTC contract `acceptOwnership` test"
       contractPropWithSender adminAddress
         validateBadSender (AcceptOwnership ()) storageInTranferOwnership
   , testCase
-      "Call to `acceptOwnership` updates admin with address of new owner and resets `newOwner` field" $
+      "Call to `acceptOwnership` updates admin with address of new owner \
+      \and resets `newOwner` field" $
       contractPropWithSender newOwnerAddress
         validateGoodOwner (AcceptOwnership ()) storageInTranferOwnership
   ]
@@ -534,7 +538,9 @@ originateV2 =
 originateAgent
   :: forall v2.
   ( InstrWrapC v2 "cMintForMigration"
-  , AppendCtorField (GetCtorField v2 "cMintForMigration") '[] ~ '[("to" :! Address, "value" :! Natural)]
+  , AppendCtorField
+      (GetCtorField v2 "cMintForMigration")
+      '[] ~ '[("to" :! Address, "value" :! Natural)]
   , KnownValue v2, NoOperation v2, NoBigMap v2)
   => Address
   -> ContractAddr v2
@@ -542,7 +548,9 @@ originateAgent
 originateAgent oldContract newContract =
   case checkOpPresence (sing @(ToT v2)) of
     OpAbsent ->
-      unContractAddress <$> lOriginate (Agent.agentContract @v2) "Migration Agent" agentStorage (toMutez 1000)
+      unContractAddress <$>
+        lOriginate (Agent.agentContract @v2)
+        "Migration Agent" agentStorage (toMutez 1000)
     OpPresent ->
       error "Cannot originate contract with operations in parameter"
     where


### PR DESCRIPTION
Problem : Currently the config file for the CLI tool is stored in
$HOME/.tzbtc/.  Putting config files in the user’s home directory is
completely unacceptable.  Each platform has the right place for storing
per-program configuration files.  On Linux these are specified by the
XDG Base Directory.

Solution: Use the `xdg-basedir` library [1] to get XDG compliant config
file location. 

On Linux this makes the config file created at `~/.config/tzbtc/config.json`, 
and in Windows 10 at `c:\Users\<user>\Local Settings\tzbtc\config.json`

[1] https://hackage.haskell.org/package/xdg-basedir

<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-34

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
