### PR TITLE
[TBTC-27] Babylon changes in RPC

### DIFF
--- a/src/Client/API.hs
+++ b/src/Client/API.hs
@@ -4,6 +4,7 @@
  -}
 module Client.API
   ( forgeOperation
+  , getMainChainId
   , getCounter
   , getStorage
   , getLastBlock
@@ -33,7 +34,8 @@ type NodeAPI =
   "chains/main/blocks/head/helpers/scripts/run_operation"
   :> ReqBody '[JSON] RunOperation :> Post '[JSON] RunRes :<|>
   "chains/main/blocks/head/context/contracts"
-  :> Capture "contract" Text :> "storage" :> Get '[JSON] Expression
+  :> Capture "contract" Text :> "storage" :> Get '[JSON] Expression :<|>
+  "chains/main/chain_id" :> Get '[JSON] Text
 
 
 nodeAPI :: Proxy NodeAPI
@@ -45,9 +47,11 @@ injectOperation :: Maybe Text -> Text -> ClientM Text
 getCounter :: Text -> ClientM TezosWord64
 runOperation :: RunOperation -> ClientM RunRes
 getStorage :: Text -> ClientM Expression
+getMainChainId :: ClientM Text
 forgeOperation :<|>
   getLastBlock :<|>
   injectOperation :<|>
   getCounter :<|>
   runOperation :<|>
-  getStorage = client nodeAPI
+  getStorage :<|>
+  getMainChainId = client nodeAPI


### PR DESCRIPTION
<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

Problem: `tzbtc-client` doesn't work on `babylonnet` due to changes
in the RPC API.

Solution: Update servant client API to make it match current version
of RPC API.

Actually, I'm not sure whether we should merge this changes in `master` now.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-27

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
