### PR TITLE
[TBTC-43] Print annotations when printing contracts

### DIFF
--- a/test.bats
+++ b/test.bats
@@ -81,7 +81,10 @@
 }
 
 @test "invoking tzbtc 'printContract' command with --oneline flag" {
-  stack exec -- tzbtc printContract --oneline
+  result="$(stack exec -- tzbtc printContract --oneline)"
+  [[ "$result" == *"%transfer"* ]]
+  [[ "$result" == *"%approve"* ]]
+  [[ "$result" == *"%mint"* ]]
 }
 
 @test "invoking tzbtc 'printAgentContract' command" {
@@ -97,7 +100,10 @@
 }
 
 @test "invoking tzbtc 'printProxyContract' command with --oneline flag" {
-  stack exec -- tzbtc printProxyContract --oneline
+  result="$(stack exec -- tzbtc printProxyContract --oneline)"
+  [[ "$result" == *"%transfer"* ]]
+  [[ "$result" == *"%approve"* ]]
+  [[ "$result" == *"%getAllowance"* ]]
 }
 
 @test "invoking tzbtc 'printContractDoc' command" {


### PR DESCRIPTION
Problem : The commands that print tzbtc contracts now do so without
including annotations. Change it so that annotations are included in the
output.

Solution : Print the contracts using something other then `lcwDumb`.

Tests : Tests were added to test that the output from contract printing
commands contains some expected entry points.

<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-43

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
