### PR TITLE
[TBTC-44] Convenient getters

### DIFF
--- a/client/Main.hs
+++ b/client/Main.hs
@@ -48,14 +48,26 @@ main = do
         spender <- addrOrAliasToAddr spender'
         runTzbtcContract $
           EntrypointsWithoutView $ Approve (#spender .! spender, #value .! value)
-      CmdGetAllowance (owner', spender') callback' -> do
-        [owner, spender, callback] <- mapM addrOrAliasToAddr [owner', spender', callback']
-        runTzbtcContract $ EntrypointsWithView $ GetAllowance $
-          View (#owner .! owner, #spender .! spender) (ContractAddr callback)
-      CmdGetBalance owner' callback' -> do
-        [owner, callback] <- mapM addrOrAliasToAddr [owner', callback']
-        runTzbtcContract $
-          EntrypointsWithView $ GetBalance $ View owner (ContractAddr callback)
+      CmdGetAllowance (owner', spender') mbCallback' ->
+        case mbCallback' of
+          Just callback' -> do
+            [owner, spender, callback] <- mapM addrOrAliasToAddr [owner', spender', callback']
+            runTzbtcContract $ EntrypointsWithView $ GetAllowance $
+              View (#owner .! owner, #spender .! spender) (ContractAddr callback)
+          Nothing -> do
+            [owner, spender] <- mapM addrOrAliasToAddr [owner', spender']
+            allowance <- getAllowance owner spender
+            putStrLn ("Allowance: " <> show allowance :: Text)
+      CmdGetBalance owner' mbCallback' -> do
+        case mbCallback' of
+          Just callback' -> do
+            [owner, callback] <- mapM addrOrAliasToAddr [owner', callback']
+            runTzbtcContract $
+              EntrypointsWithView $ GetBalance $ View owner (ContractAddr callback)
+          Nothing -> do
+            owner <- addrOrAliasToAddr owner'
+            balance <- getBalance owner
+            putStrLn ("Balance: " <> show balance :: Text)
       CmdAddOperator operator' mbMultisig -> do
         operator <- addrOrAliasToAddr operator'
         runMultisigTzbtcContract mbMultisig $

--- a/package.yaml
+++ b/package.yaml
@@ -31,6 +31,7 @@ library:
     - directory
     - hex-text
     - http-client
+    - http-types
     - fmt
     - memory
     - morley
@@ -48,10 +49,6 @@ library:
     - universum
     - safe-exceptions
     - vinyl
-    - hex-text
-    - bytestring
-    - aeson
-    - aeson-casing
     - xdg-basedir
 
 executables:

--- a/src/Client/API.hs
+++ b/src/Client/API.hs
@@ -4,6 +4,7 @@
  -}
 module Client.API
   ( forgeOperation
+  , getFromBigMap
   , getMainChainId
   , getCounter
   , getStorage
@@ -35,7 +36,9 @@ type NodeAPI =
   :> ReqBody '[JSON] RunOperation :> Post '[JSON] RunRes :<|>
   "chains/main/blocks/head/context/contracts"
   :> Capture "contract" Text :> "storage" :> Get '[JSON] Expression :<|>
-  "chains/main/chain_id" :> Get '[JSON] Text
+  "chains/main/chain_id" :> Get '[JSON] Text :<|>
+  "chains/main/blocks/head/context/big_maps" :> Capture "big_map_id" Natural
+  :> Capture "script_expr" Text :> Get '[JSON] Expression
 
 
 nodeAPI :: Proxy NodeAPI
@@ -48,10 +51,12 @@ getCounter :: Text -> ClientM TezosWord64
 runOperation :: RunOperation -> ClientM RunRes
 getStorage :: Text -> ClientM Expression
 getMainChainId :: ClientM Text
+getFromBigMap :: Natural -> Text -> ClientM Expression
 forgeOperation :<|>
   getLastBlock :<|>
   injectOperation :<|>
   getCounter :<|>
   runOperation :<|>
   getStorage :<|>
-  getMainChainId = client nodeAPI
+  getMainChainId :<|>
+  getFromBigMap = client nodeAPI

--- a/src/Client/Error.hs
+++ b/src/Client/Error.hs
@@ -21,7 +21,6 @@ data TzbtcClientError
   | TzbtcClientConfigFileNotFound FilePath
   | TzbtcRunFailed [RunError]
   | TzbtcUnexpectedRunResult Text
-  | TzbtcUnexpectedMultisigStorage MichelsonExpression
   | TzbtcPublicKeyParseError Text CryptoParseError
   | TzbtcUnknownAliasError Text
   | TzbtcMutlisigConfigUnavailable
@@ -59,10 +58,6 @@ instance Buildable TzbtcClientError where
 
   build (TzbtcUnexpectedRunResult msg) =
     "Unexpected result of transaction preliminary run: " +| msg |+ ""
-
-  build (TzbtcUnexpectedMultisigStorage stor) =
-    "Multisig contract has unexpected storage: " +| stor |+ "\n" <>
-    "Expecting the following storage (counter, (treshold, [keys]))"
 
   build (TzbtcPublicKeyParseError pk err) =
     "Failed to parse public key " +| pk |+ " with: " +| err |+ ""

--- a/src/Client/Parser.hs
+++ b/src/Client/Parser.hs
@@ -14,8 +14,8 @@ module Client.Parser
 import Data.Char (isAlpha, isDigit, toUpper)
 import Fmt (pretty)
 import Options.Applicative
-  (argument, auto, eitherReader, help, long, metavar, option,
-  showDefaultWith, str, switch, value)
+  (argument, auto, eitherReader, help, long, metavar, option, optional,
+  showDefaultWith, str, strOption, switch, value)
 import qualified Options.Applicative as Opt
 import qualified Text.Megaparsec as P
   (Parsec, customFailure, many, parse, satisfy)
@@ -40,8 +40,8 @@ data ClientArgsRaw
   | CmdBurn BurnParams (Maybe FilePath)
   | CmdTransfer AddrOrAlias AddrOrAlias Natural
   | CmdApprove AddrOrAlias Natural
-  | CmdGetAllowance (AddrOrAlias, AddrOrAlias) AddrOrAlias
-  | CmdGetBalance AddrOrAlias AddrOrAlias
+  | CmdGetAllowance (AddrOrAlias, AddrOrAlias) (Maybe AddrOrAlias)
+  | CmdGetBalance AddrOrAlias (Maybe AddrOrAlias)
   | CmdAddOperator AddrOrAlias (Maybe FilePath)
   | CmdRemoveOperator AddrOrAlias (Maybe FilePath)
   | CmdPause (Maybe FilePath)
@@ -78,6 +78,7 @@ clientArgRawParser = Opt.hsubparser $
   <> addSignatureCmd <> signPackageCmd <> callMultisigCmd
   <> addSignatureCmd <> callMultisigCmd <> configCmd
   where
+    multisigOption :: Opt.Parser (Maybe FilePath)
     multisigOption =
       Opt.optional $ Opt.strOption $ mconcat
       [ long "multisig"
@@ -167,7 +168,7 @@ clientArgRawParser = Opt.hsubparser $
          (CmdGetAllowance <$>
           ((,) <$> addrOrAliasOption "owner" "Address of the owner" <*>
           addrOrAliasOption "spender" "Address of the spender") <*>
-          addrOrAliasOption "callback" "Callback address"
+          mbAddrOrAliasOption "callback" "Callback address"
          )
          "Get allowance for an account")
     getBalanceCmd :: Opt.Mod Opt.CommandFields ClientArgsRaw
@@ -176,7 +177,7 @@ clientArgRawParser = Opt.hsubparser $
          "getBalance"
          (CmdGetBalance <$>
           addrOrAliasOption "address" "Address of the owner" <*>
-          addrOrAliasOption "callback" "Callback address"
+          mbAddrOrAliasOption "callback" "Callback address"
          )
          "Get balance for an account")
     addOperatorCmd :: Opt.Mod Opt.CommandFields ClientArgsRaw
@@ -303,6 +304,14 @@ clientArgRawParser = Opt.hsubparser $
 addrOrAliasOption :: String -> String -> Opt.Parser AddrOrAlias
 addrOrAliasOption name hInfo =
   option str $ mconcat
+  [ metavar "ADDRESS | ALIAS"
+  , long name
+  , help hInfo
+  ]
+
+mbAddrOrAliasOption :: String -> String -> Opt.Parser (Maybe AddrOrAlias)
+mbAddrOrAliasOption name hInfo =
+  optional $ strOption $ mconcat
   [ metavar "ADDRESS | ALIAS"
   , long name
   , help hInfo

--- a/src/Client/Types.hs
+++ b/src/Client/Types.hs
@@ -3,7 +3,8 @@
  - SPDX-License-Identifier: LicenseRef-Proprietary
  -}
 module Client.Types
-  ( ClientConfigP (..)
+  ( AlmostStorage (..)
+  , ClientConfigP (..)
   , ClientConfig
   , ClientConfigPartial
   , ForgeOperation (..)
@@ -39,8 +40,11 @@ import Tezos.Micheline
   (Expression(..), MichelinePrimAp(..), MichelinePrimitive(..))
 import Tezos.Json (TezosWord64(..))
 
+import Michelson.Typed (IsoValue)
 import Tezos.Address (Address)
 import Tezos.Crypto (Signature, encodeBase58Check)
+
+import Lorentz.Contracts.TZBTC.Types (StorageFields)
 
 newtype MichelsonExpression = MichelsonExpression Expression
   deriving newtype FromJSON
@@ -59,6 +63,12 @@ instance Buildable MichelsonExpression where
       buildSeq =
         mconcat . intersperse ", " . map
         (build . MichelsonExpression) . toList
+
+data AlmostStorage = AlmostStorage
+  { asBigMapId :: Natural
+  , asFields :: StorageFields
+  } deriving stock (Show, Generic)
+    deriving anyclass IsoValue
 
 data ForgeOperation = ForgeOperation
   { foBranch :: Text

--- a/src/Client/Util.hs
+++ b/src/Client/Util.hs
@@ -5,13 +5,14 @@
 module Client.Util
   ( addTezosBytesPrefix
   , calcFees
-  , exprToMultisigStorage
+  , exprToValue
   , paramToExpression
   , throwClientError
   , throwLeft
+  , valueToScriptExpr
   ) where
 
-import qualified Data.ByteString as BS (cons, drop)
+import qualified Data.ByteString as BS (cons, drop, pack)
 import Servant.Client.Core (ClientError)
 import Tezos.Binary (encode, decode)
 import Tezos.Json (TezosWord64)
@@ -21,10 +22,10 @@ import Lorentz.Constraints (KnownValue, NoBigMap, NoOperation)
 import Michelson.Interpret.Pack (packValue')
 import Michelson.Interpret.Unpack (UnpackError, dummyUnpackEnv, unpackValue')
 import Michelson.Typed.Haskell.Value (IsoValue(..))
-import Michelson.Typed.Scope (forbiddenBigMap, forbiddenOp)
+import Michelson.Typed.Scope (HasNoOp, HasNoBigMap, forbiddenBigMap, forbiddenOp)
+import Tezos.Crypto (blake2b)
 
 import Client.Error (TzbtcClientError(..))
-import qualified Lorentz.Contracts.TZBTC.MultiSig as MSig (Storage)
 
 paramToExpression
   :: forall param.
@@ -55,9 +56,29 @@ throwLeft =
       Left e -> throwM e
       Right x -> return x)
 
-exprToMultisigStorage :: Expression -> Either UnpackError MSig.Storage
-exprToMultisigStorage =
-  fmap fromVal . unpackValue' dummyUnpackEnv . BS.cons 0x05 . encode
-
 addTezosBytesPrefix :: Text -> Text
 addTezosBytesPrefix = ("0x" <>)
+
+exprToValue
+  :: forall t. (IsoValue t, KnownValue t, HasNoOp (ToT t), HasNoBigMap (ToT t))
+  => Expression -> Either UnpackError t
+exprToValue =
+  fmap fromVal . unpackValue' @(ToT t) dummyUnpackEnv . BS.cons 0x05 . encode
+
+addExprPrefix :: ByteString -> ByteString
+addExprPrefix = (BS.pack [0x0D, 0x2C, 0x40, 0x1B] <>)
+
+
+-- | This function transforms Lorentz value into `script_expr`.
+--
+-- `script_expr` is used in RPC as an argument in entrypoint
+-- designed for getting value by key from the big_map in Babylon.
+-- In order to convert value to the `script_expr` we have to pack it,
+-- take blake2b hash and add specific `expr` prefix. Take a look at
+-- https://gitlab.com/tezos/tezos/blob/6e25ae8eb385d9975a30388c7a7aa2a9a65bf184/src/proto_005_PsBabyM1/lib_protocol/script_expr_hash.ml
+-- and https://gitlab.com/tezos/tezos/blob/6e25ae8eb385d9975a30388c7a7aa2a9a65bf184/src/proto_005_PsBabyM1/lib_protocol/contract_services.ml#L136
+-- for more information.
+valueToScriptExpr
+  :: forall t. (IsoValue t, KnownValue t, HasNoOp (ToT t), HasNoBigMap (ToT t))
+  => t -> ByteString
+valueToScriptExpr = addExprPrefix . blake2b . packValue' . toVal

--- a/src/Lorentz/Contracts/TZBTC/Types.hs
+++ b/src/Lorentz/Contracts/TZBTC/Types.hs
@@ -132,7 +132,7 @@ data StorageFields = StorageFields
   , migrationManagerIn :: Maybe MigrationManager
   , migrationManagerOut :: Maybe MigrationManager
   , proxy :: Either Address Address
-  } deriving stock Generic
+  } deriving stock (Show, Generic)
     deriving anyclass IsoValue
 
 instance HasFieldOfType StorageFields name field =>

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,6 @@ packages:
 - .
 
 extra-deps:
-
 - git:
     https://gitlab.com/morley-framework/morley.git
     # ^ CI cannot use ssh, so we use http clone here

--- a/test.bats
+++ b/test.bats
@@ -32,10 +32,21 @@
     --callback "KT1SyriCZ2kDyEMJ6BtQecGkFqVciQcfWj46" --dry-run
 }
 
+@test "invoking tzbtc-client 'getAllowance' command without callback" {
+  stack exec -- tzbtc-client getAllowance\
+    --owner "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"\
+    --spender "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" --dry-run
+}
+
 @test "invoking tzbtc-client 'getBalance' command" {
   stack exec -- tzbtc-client getBalance\
     --address "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"\
     --callback "KT1SyriCZ2kDyEMJ6BtQecGkFqVciQcfWj46" --dry-run
+}
+
+@test "invoking tzbtc-client 'getBalance' command without callback" {
+  stack exec -- tzbtc-client getBalance\
+    --address "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV" --dry-run
 }
 
 @test "invoking tzbtc-client 'addOperator' command" {


### PR DESCRIPTION
<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

Problem: Currently `getBalance` and `getAllowance` are implemented as
view entrypoints and there is no user-friendly way to use them from CLI.

Solution: Make `--callback <addr>` argument optional so that if this
argument isn't provided, we directly get the contract storage using RPC
and return values from it without calling other contracts.

Note that currently this PR based on #37 and also https://gitlab.com/morley-framework/morley/merge_requests/81

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-44

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
