### PR TITLE
[TBTC-51] Config edit via external editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,14 @@ ledger interaction.
 environment. It takes information about node, user information
 (specifically address and name alias from the `tezos-client`), contract address
 and also path to the `tezos-client` executable, which is used for
-transaction signing and ledger interaction.
+transaction signing and ledger interaction. The `setupClient` command
+can be called without any values, which places a template config file in
+the proper path, filled with placeholders. The `config --edit` command
+can be used to edit the config values in the file. When called with no
+arguments, `config --edit` command will open an editor (Not available in
+windows), with the config contents. After saving the content and
+closing the editor, the config file will be updated with the new
+contents.
 
 Other commands will perform injection of desired transaction to the
 TZBTC contract. E.g. `tzbtc-client mint --to tz1U1h1YzBJixXmaTgpwDpZnbrYHX3fMSpvby --value 100500`

--- a/package.yaml
+++ b/package.yaml
@@ -51,6 +51,10 @@ library:
     - vinyl
     - xdg-basedir
 
+  when:
+    - condition: os(linux)
+      dependencies: editor-open
+
 executables:
   tzbtc:
     <<: *exec-common
@@ -83,6 +87,7 @@ tests:
       - DerivingStrategies
 
     dependencies:
+    - aeson
     - tzbtc
     - morley-prelude
     - universum

--- a/src/Util/Editor.hs
+++ b/src/Util/Editor.hs
@@ -1,0 +1,29 @@
+{- SPDX-FileCopyrightText: 2019 Bitcoin Suisse
+ -
+ - SPDX-License-Identifier: LicenseRef-Proprietary
+ -}
+{-# LANGUAGE CPP #-}
+
+module Util.Editor
+  ( editConfigViaEditor
+  ) where
+
+#ifdef mingw32_HOST_OS
+
+editConfigViaEditor :: FilePath -> IO ()
+editConfigViaEditor _ =
+  putTextLn "This feature is not available in Windows environment."
+
+#else
+
+import Data.ByteString (writeFile)
+import Text.Editor (jsonTemplate, runUserEditorDWIMFile)
+
+editConfigViaEditor :: FilePath -> IO ()
+editConfigViaEditor path = do
+  newContents <- runUserEditorDWIMFile jsonTemplate path
+  writeFile path newContents
+  putTextLn "Config file was updated successfully"
+
+#endif
+

--- a/test/Test/CLI.hs
+++ b/test/Test/CLI.hs
@@ -1,0 +1,62 @@
+{- SPDX-FileCopyrightText: 2019 Bitcoin Suisse
+ -
+ - SPDX-License-Identifier: LicenseRef-Proprietary
+ -}
+module Test.CLI
+  ( test_toConfigFilled
+  , test_jsonEncodingOfPartialValues
+  ) where
+
+import qualified Universum.Unsafe as Unsafe (fromJust)
+
+import Data.Aeson (encode, decode)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, testCase, (@?=))
+
+import Tezos.Address
+import Client.Types
+
+contractAddress :: Address
+contractAddress = unsafeParseAddress "KT19rTTBPeG1JAvrECgoQ8LJj1mJrN7gsdaH"
+
+userAddress :: Address
+userAddress = unsafeParseAddress "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx"
+
+test_toConfigFilled :: TestTree
+test_toConfigFilled = testGroup "Building ClientConfig from ConfigPartial works as expected"
+  [ testCase "Handle values correctly with placeholders" $
+    (toConfigFilled partialConfigBad) @?= Nothing
+  , testCase "Handle correctly when all required values are available" $
+    assertBool "Returns completed config when all required options are available"
+      (isJust $ toConfigFilled partialConfigGood)
+  ]
+  where
+    partialConfigGood :: ClientConfigPartial
+    partialConfigGood = ClientConfig
+      { ccNodeAddress = Available "localhost"
+      , ccNodePort = Available 9000
+      , ccContractAddress = Available contractAddress
+      , ccMultisigAddress = Available (Just contractAddress)
+      , ccUserAddress = Available userAddress
+      , ccUserAlias = Available "alice"
+      , ccTezosClientExecutable = Available "/bin/tezos-client"
+      }
+    partialConfigBad :: ClientConfigPartial
+    partialConfigBad = ClientConfig
+      { ccNodeAddress = Available "localhost"
+      , ccNodePort = Available 9000
+      , ccContractAddress = Available contractAddress
+      , ccMultisigAddress = Available (Just contractAddress)
+      , ccUserAddress = Available userAddress
+      , ccUserAlias = Available "-- some text"
+      , ccTezosClientExecutable = Available "/bin/tezos-client"
+      }
+
+test_jsonEncodingOfPartialValues :: TestTree
+test_jsonEncodingOfPartialValues =
+  testGroup "Incomplete values are replaced with placeholders in proper format"
+    [ testCase "Generates placeholder values correctly" $
+        assertBool "-- prefix is included" $
+          (isPrefixOf "-- " $  Unsafe.fromJust $ decode $ encode partialValue )]
+  where
+    partialValue = Unavilable :: Partial "fieldname" (Maybe Text)


### PR DESCRIPTION
Problem : We have a config command with --edit flag that lets user edit
various config values by providing them in the command line. But it
would be better if we can open an external editor to let the config
values more easily. A problem here is that the concept of default editor
only exist in Linux like operating system, and not on windows. The lib
we are using to open the default editor, was also not available in
Windows.

Solution : Use conditional dependencies to detect os and include the
`editor-open` package. Use conditional pragmas in code to print out a
'not available on windows' error upon the invocation of this command.

In addition to this, this PR implements a number of changes so that the
config editing via `--edit` switch also works well together with the
`setupClient` command behavior. Basically an option to read config as
raw text values was added, and the `--edit` operation now reads/write
raw text values instead of values of the actual field types. The user
input is parsed properly in as part of the command, so there is less
chance that a bad value could end up in the config. The current behavior
can be summarised as follows.

At the start user invokes `setupClient` command. If the required
values are missing, then those fields will be replaced with a
placeholder in the generated config file. After this user will be able
to set individual fields using the `--edit` switch. This is possible
even with the presence of placeholders in the file. After editing, the
config file is checked for validity, and if found invalid, a warning is
printed out. For multi-sig, the user will be able to provide a `null`
value to the --multisig-address option to unset the placeholder or
existing value.

At any point, the user will be able to call the `--edit` command without
any additional field, and the config content will be opened in the
configured editor. In windows, an message will be printed out that says
the feature is not available in Windows.

Tests: Couple of tests have been included that test that the placeholder
values are properly generated, and while reading these placeholders are
processed properly.

<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-51

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [ ] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
