### PR TITLE
[QuickFix] Make the contract have FA1.2 (and other) entrypoints

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -15,12 +15,11 @@ import Options.Applicative.Help.Pretty (Doc, linebreak)
 
 import Lorentz
 import Lorentz.Common (showTestScenario)
-import Util.IO (writeFileUtf8)
 import Paths_tzbtc (version)
+import Util.IO (writeFileUtf8)
 
 import CLI.Parser
-import Lorentz.Contracts.TZBTC
-  (Parameter(..), agentContract, mkStorage, tzbtcContract, tzbtcDoc)
+import Lorentz.Contracts.TZBTC (Parameter(..), agentContract, mkStorage, tzbtcContract, tzbtcDoc)
 import Lorentz.Contracts.TZBTC.Proxy (tzbtcProxyContract)
 import Lorentz.Contracts.TZBTC.Test (mkTestScenario)
 
@@ -32,7 +31,7 @@ main = do
   cmd <- execParser programInfo
   case cmd of
     CmdPrintContract singleLine mbFilePath ->
-      printContract singleLine mbFilePath lcwEntryPoints tzbtcContract
+      printContract singleLine mbFilePath lcwEntryPointsRecursive tzbtcContract
     CmdPrintAgentContract singleLine mbFilePath ->
       printContract singleLine mbFilePath lcwDumb (agentContract @Parameter)
         -- Here agentContract that is printed is the one that target a
@@ -96,4 +95,3 @@ usageDoc =
     , "  of TZBTC contract storage that can later be used for", linebreak
     , "  contract origination using tezos-client", linebreak
     ]
-

--- a/test.bats
+++ b/test.bats
@@ -129,8 +129,12 @@
 
 @test "invoking tzbtc 'printContract' command with --oneline flag" {
   result="$(stack exec -- tzbtc printContract --oneline)"
-  [[ "$result" == *"%entrypointsWithView"* ]]
-  [[ "$result" == *"%entrypointsWithoutView"* ]]
+  [[ "$result" == *"%transfer"* ]]
+  [[ "$result" == *"%approve"* ]]
+  [[ "$result" == *"%getBalance"* ]]
+  [[ "$result" == *"%getAllowance"* ]]
+  [[ "$result" == *"%getTotalSupply"* ]]
+  [[ "$result" == *"%mint"* ]]
 }
 
 @test "invoking tzbtc 'printAgentContract' command" {


### PR DESCRIPTION
## Description

Problem: the contract has only two entrypoints:
* %entrypointsWithView
* %entrypointsWithoutView
FA1.2 requires other entrypoints and we want to support FA1.2.

Solution: use `lcwEntryPointsRecursive` to have all required
entrypoints.

## Related issue(s)

None

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
