### PR TITLE
[TBTC-60] Get rid of `ccUserAddress`

### DIFF
--- a/src/Client/IO.hs
+++ b/src/Client/IO.hs
@@ -415,8 +415,7 @@ runConfigEdit doEdit configPartial = do
     hasDelta ccp =
       isAvailable (ccNodeAddress ccp) || isAvailable (ccNodePort ccp) ||
       isAvailable (ccContractAddress ccp) || isAvailable (ccMultisigAddress ccp) ||
-      isAvailable (ccUserAlias ccp) || isAvailable (ccTezosClientExecutable ccp) ||
-      isAvailable (ccUserAddress ccp)
+      isAvailable (ccUserAlias ccp) || isAvailable (ccTezosClientExecutable ccp)
 
     mergeConfig :: ClientConfigText -> ClientConfigPartial -> ClientConfigText
     mergeConfig cc ccp = ClientConfig
@@ -424,7 +423,6 @@ runConfigEdit doEdit configPartial = do
       (withDefaultConfig (ccNodePort cc) (ccNodePort ccp))
       (withDefaultConfig (ccContractAddress cc) (ccContractAddress ccp))
       (withDefaultConfig (ccMultisigAddress cc) (ccMultisigAddress ccp))
-      (withDefaultConfig (ccUserAddress cc) (ccUserAddress ccp))
       (withDefaultConfig (ccUserAlias cc) (ccUserAlias ccp))
       (withDefaultConfig (ccTezosClientExecutable cc) (ccTezosClientExecutable ccp))
 

--- a/src/Client/Parser.hs
+++ b/src/Client/Parser.hs
@@ -108,7 +108,6 @@ clientArgRawParser = Opt.hsubparser $
       (partialParser $ namedAddressOption Nothing "contract-address"
       "Contract's address") <*>
       (partialParserMaybe $ namedAddressOption Nothing "multisig-address" "Multisig contract address") <*>
-      (partialParser $ namedAddressOption Nothing "user-address" "User's address") <*>
       (partialParser $ option str $ mconcat
        [ long "alias"
        , metavar "ADDRESS_ALIAS"
@@ -125,7 +124,6 @@ clientArgRawParser = Opt.hsubparser $
         optional $ nullableAddressOption
           ! #name "multisig-address"
           ! #hinfo "Multisig contract address. Use 'null' to clear current value.") <*>
-      (partialParser $ namedAddressOption Nothing "user-address" "User's address") <*>
       (partialParser $ option str $ mconcat
        [ long "alias"
        , metavar "ADDRESS_ALIAS"

--- a/src/Client/Types.hs
+++ b/src/Client/Types.hs
@@ -245,7 +245,6 @@ data ClientConfigP f = ClientConfig
   , ccNodePort :: ConfigC f Int "`rpc port of the tezos node"
   , ccContractAddress :: ConfigC f Address "contract address"
   , ccMultisigAddress :: ConfigC f (Maybe Address) "multisig contract address"
-  , ccUserAddress :: ConfigC f Address "user address"
   , ccUserAlias :: ConfigC f Text "user alias"
   , ccTezosClientExecutable :: ConfigC f FilePath "tezos-client executable path"
   } deriving Generic
@@ -282,7 +281,6 @@ toConfigFilled p = ClientConfig
   <*> (toMaybe $ ccNodePort p)
   <*> (toMaybe $ ccContractAddress p)
   <*> (toMaybe $ withDefault' Nothing $ ccMultisigAddress p)
-  <*> (toMaybe $ ccUserAddress p)
   <*> (toMaybeText $ ccUserAlias p)
   <*> (toMaybe $ ccTezosClientExecutable p)
   where

--- a/test.bats
+++ b/test.bats
@@ -171,9 +171,9 @@
 }
 
 @test "invoking tzbtc 'config --edit' command with available arguments" {
-  stack exec -- tzbtc-client config --edit --node-url "localhost" --node-port "9900" --contract-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --multisig-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --user-address "tz1VwXeEPw2tkTgDSUUbEb5fe63b24gNEssa" --alias alice --tezos-client /local/bin/tezos-client
+  stack exec -- tzbtc-client config --edit --node-url "localhost" --node-port "9900" --contract-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --multisig-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --alias alice --tezos-client /local/bin/tezos-client
 }
 
 @test "invoking tzbtc 'setupClient' command with arguments" {
-  stack exec -- tzbtc-client setupClient --node-url "localhost" --node-port "9900" --contract-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --multisig-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --user-address "tz1VwXeEPw2tkTgDSUUbEb5fe63b24gNEssa" --alias alice --tezos-client /local/bin/tezos-client
+  stack exec -- tzbtc-client setupClient --node-url "localhost" --node-port "9900" --contract-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --multisig-address "KT1HmhmNcZKmm2NsuyahdXAaHQwYfWfdrBxi" --alias alice --tezos-client /local/bin/tezos-client
 }

--- a/test/Test/CLI.hs
+++ b/test/Test/CLI.hs
@@ -19,9 +19,6 @@ import Client.Types
 contractAddress :: Address
 contractAddress = unsafeParseAddress "KT19rTTBPeG1JAvrECgoQ8LJj1mJrN7gsdaH"
 
-userAddress :: Address
-userAddress = unsafeParseAddress "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx"
-
 test_toConfigFilled :: TestTree
 test_toConfigFilled = testGroup "Building ClientConfig from ConfigPartial works as expected"
   [ testCase "Handle values correctly with placeholders" $
@@ -37,7 +34,6 @@ test_toConfigFilled = testGroup "Building ClientConfig from ConfigPartial works 
       , ccNodePort = Available 9000
       , ccContractAddress = Available contractAddress
       , ccMultisigAddress = Available (Just contractAddress)
-      , ccUserAddress = Available userAddress
       , ccUserAlias = Available "alice"
       , ccTezosClientExecutable = Available "/bin/tezos-client"
       }
@@ -47,7 +43,6 @@ test_toConfigFilled = testGroup "Building ClientConfig from ConfigPartial works 
       , ccNodePort = Available 9000
       , ccContractAddress = Available contractAddress
       , ccMultisigAddress = Available (Just contractAddress)
-      , ccUserAddress = Available userAddress
       , ccUserAlias = Available "-- some text"
       , ccTezosClientExecutable = Available "/bin/tezos-client"
       }


### PR DESCRIPTION
<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

Problem: We don't use user address from config file
and obtain using via tezos-client since TBTC-31. However,
it accidentally appeared in ClientConfig.

Solution: Remove all appearances of `ccUserAddress`.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-60

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
