### PR TITLE
[TBTC-62] Merge `admin` and `master` fields

### DIFF
--- a/ContractDoc.md
+++ b/ContractDoc.md
@@ -300,37 +300,6 @@ Pass resulting value as parameter to the contract.
 
 ---
 
-##### `SetMaster`
-
-This entry point is used to set the master of the contract.
-
-**Parameter:** [`Address`](#types-Address)
-
-<details>
-  <summary><b>How to call this entry point</b></summary>
-
-0. Construct parameter for the entry point.
-1. Wrap into `SetMaster` constructor.
-    + **In Haskell:** `SetMaster (·)`
-    + **In Michelson:** `Left (Left (Right (Left (·))))`
-1. Wrap into `SafeEntrypoints` constructor.
-    + **In Haskell:** `SafeEntrypoints (·)`
-    + **In Michelson:** `Right (Right (Right (·)))`
-
-Pass resulting value as parameter to the contract.
-
-</details>
-<p>
-
-
-
-**Possible errors:**
-* [`SenderIsNotAdmin`](#errors-SenderIsNotAdmin) — Entrypoint executed not by its administrator.
-
-
-
----
-
 ##### `EpwBeginUpgrade`
 
 This entry point is used to start an entrypoint wise upgrade of the contract.
@@ -343,7 +312,7 @@ This entry point is used to start an entrypoint wise upgrade of the contract.
 0. Construct parameter for the entry point.
 1. Wrap into `EpwBeginUpgrade` constructor.
     + **In Haskell:** `EpwBeginUpgrade (·)`
-    + **In Michelson:** `Left (Left (Right (Right (·))))`
+    + **In Michelson:** `Left (Left (Right (Left (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `SafeEntrypoints (·)`
     + **In Michelson:** `Right (Right (Right (·)))`
@@ -378,7 +347,7 @@ This entry point is used to apply an migration script as part of an upgrade.
 0. Construct parameter for the entry point.
 1. Wrap into `EpwApplyMigration` constructor.
     + **In Haskell:** `EpwApplyMigration (·)`
-    + **In Michelson:** `Left (Right (Left (Left (·))))`
+    + **In Michelson:** `Left (Left (Right (Right (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `SafeEntrypoints (·)`
     + **In Michelson:** `Right (Right (Right (·)))`
@@ -411,7 +380,7 @@ This entry point is used to set the dispatching code that calls the packed entry
 0. Construct parameter for the entry point.
 1. Wrap into `EpwSetCode` constructor.
     + **In Haskell:** `EpwSetCode (·)`
-    + **In Michelson:** `Left (Right (Left (Right (·))))`
+    + **In Michelson:** `Left (Right (Left (Left (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `SafeEntrypoints (·)`
     + **In Michelson:** `Right (Right (Right (·)))`
@@ -444,7 +413,7 @@ This entry point is used to mark that an upgrade has been finsihed.
 0. Construct parameter for the entry point.
 1. Wrap into `EpwFinishUpgrade` constructor.
     + **In Haskell:** `EpwFinishUpgrade (·)`
-    + **In Michelson:** `Left (Right (Right (Left (·))))`
+    + **In Michelson:** `Left (Right (Left (Right (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `SafeEntrypoints (·)`
     + **In Michelson:** `Right (Right (Right (·)))`
@@ -477,7 +446,7 @@ This entry point is used transfer tokens from one account to another.
 0. Construct parameter for the entry point.
 1. Wrap into `Transfer` constructor.
     + **In Haskell:** `Transfer (·)`
-    + **In Michelson:** `Left (Right (Right (Right (Left (·)))))`
+    + **In Michelson:** `Left (Right (Right (Left (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `SafeEntrypoints (·)`
     + **In Michelson:** `Right (Right (Right (·)))`
@@ -508,7 +477,7 @@ This entry point is used approve transfer of tokens from one account to another.
 0. Construct parameter for the entry point.
 1. Wrap into `Approve` constructor.
     + **In Haskell:** `Approve (·)`
-    + **In Michelson:** `Left (Right (Right (Right (Right (·)))))`
+    + **In Michelson:** `Left (Right (Right (Right (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `SafeEntrypoints (·)`
     + **In Michelson:** `Right (Right (Right (·)))`
@@ -874,37 +843,6 @@ Pass resulting value as parameter to the contract.
 
 ---
 
-### `SetMaster`
-
-This entry point is used to set the master of the contract.
-
-**Parameter:** [`Address`](#types-Address)
-
-<details>
-  <summary><b>How to call this entry point</b></summary>
-
-0. Construct parameter for the entry point.
-1. Wrap into `SetMaster` constructor.
-    + **In Haskell:** `SetMaster (·)`
-    + **In Michelson:** `Left (Left (Right (Left (·))))`
-1. Wrap into `SafeEntrypoints` constructor.
-    + **In Haskell:** `Run (·)`
-    + **In Michelson:** `Right (Right (Right ((·))))`
-
-Pass resulting value as parameter to the contract.
-
-</details>
-<p>
-
-
-
-**Possible errors:**
-* [`SenderIsNotAdmin`](#errors-SenderIsNotAdmin) — Entrypoint executed not by its administrator.
-
-
-
----
-
 ### `EpwBeginUpgrade`
 
 This entry point is used to start an entrypoint wise upgrade of the contract.
@@ -917,7 +855,7 @@ This entry point is used to start an entrypoint wise upgrade of the contract.
 0. Construct parameter for the entry point.
 1. Wrap into `EpwBeginUpgrade` constructor.
     + **In Haskell:** `EpwBeginUpgrade (·)`
-    + **In Michelson:** `Left (Left (Right (Right (·))))`
+    + **In Michelson:** `Left (Left (Right (Left (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `Run (·)`
     + **In Michelson:** `Right (Right (Right ((·))))`
@@ -952,7 +890,7 @@ This entry point is used to apply an migration script as part of an upgrade.
 0. Construct parameter for the entry point.
 1. Wrap into `EpwApplyMigration` constructor.
     + **In Haskell:** `EpwApplyMigration (·)`
-    + **In Michelson:** `Left (Right (Left (Left (·))))`
+    + **In Michelson:** `Left (Left (Right (Right (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `Run (·)`
     + **In Michelson:** `Right (Right (Right ((·))))`
@@ -985,7 +923,7 @@ This entry point is used to set the dispatching code that calls the packed entry
 0. Construct parameter for the entry point.
 1. Wrap into `EpwSetCode` constructor.
     + **In Haskell:** `EpwSetCode (·)`
-    + **In Michelson:** `Left (Right (Left (Right (·))))`
+    + **In Michelson:** `Left (Right (Left (Left (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `Run (·)`
     + **In Michelson:** `Right (Right (Right ((·))))`
@@ -1018,7 +956,7 @@ This entry point is used to mark that an upgrade has been finsihed.
 0. Construct parameter for the entry point.
 1. Wrap into `EpwFinishUpgrade` constructor.
     + **In Haskell:** `EpwFinishUpgrade (·)`
-    + **In Michelson:** `Left (Right (Right (Left (·))))`
+    + **In Michelson:** `Left (Right (Left (Right (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `Run (·)`
     + **In Michelson:** `Right (Right (Right ((·))))`
@@ -1051,7 +989,7 @@ This entry point is used transfer tokens from one account to another.
 0. Construct parameter for the entry point.
 1. Wrap into `Transfer` constructor.
     + **In Haskell:** `Transfer (·)`
-    + **In Michelson:** `Left (Right (Right (Right (Left (·)))))`
+    + **In Michelson:** `Left (Right (Right (Left (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `Run (·)`
     + **In Michelson:** `Right (Right (Right ((·))))`
@@ -1082,7 +1020,7 @@ This entry point is used approve transfer of tokens from one account to another.
 0. Construct parameter for the entry point.
 1. Wrap into `Approve` constructor.
     + **In Haskell:** `Approve (·)`
-    + **In Michelson:** `Left (Right (Right (Right (Right (·)))))`
+    + **In Michelson:** `Left (Right (Right (Right (·))))`
 1. Wrap into `SafeEntrypoints` constructor.
     + **In Haskell:** `Run (·)`
     + **In Michelson:** `Right (Right (Right ((·))))`
@@ -1509,7 +1447,6 @@ Parameter which does not have unsafe arguments, like raw `Contract p` values.
 **Structure:** *one of*
 + **Run** [`UParam`](#types-Upgradable-parameter)
 + **Upgrade** (***newVersion*** : [`Natural`](#types-Natural), ***migrationScript*** : [`MigrationScript`](#types-MigrationScript), ***newCode*** : [`UContractRouter`](#types-UContractRouter))
-+ **SetMaster** [`Address`](#types-Address)
 + **EpwBeginUpgrade** [`Natural`](#types-Natural)
 + **EpwApplyMigration** (***migrationscript*** : [`MigrationScript`](#types-MigrationScript))
 + **EpwSetCode** (***contractcode*** : [`UContractRouter`](#types-UContractRouter))
@@ -1527,7 +1464,7 @@ Parameter which does not have unsafe arguments, like raw `Contract p` values.
 + **AcceptOwnership** [`()`](#types-lparenrparen)
 
 
-**Final Michelson representation:** `or (or (or (or (pair string bytes) (pair nat (pair (lambda (big_map bytes bytes) (big_map bytes bytes)) (lambda (pair (pair string bytes) (big_map bytes bytes)) (pair (list operation) (big_map bytes bytes)))))) (or address nat)) (or (or (lambda (big_map bytes bytes) (big_map bytes bytes)) (lambda (pair (pair string bytes) (big_map bytes bytes)) (pair (list operation) (big_map bytes bytes)))) (or unit (or (pair address (pair address nat)) (pair address nat))))) (or (or (or (pair address nat) nat) (or address address)) (or (or address unit) (or unit (or address unit))))`
+**Final Michelson representation:** `or (or (or (or (pair string bytes) (pair nat (pair (lambda (big_map bytes bytes) (big_map bytes bytes)) (lambda (pair (pair string bytes) (big_map bytes bytes)) (pair (list operation) (big_map bytes bytes)))))) (or nat (lambda (big_map bytes bytes) (big_map bytes bytes)))) (or (or (lambda (pair (pair string bytes) (big_map bytes bytes)) (pair (list operation) (big_map bytes bytes))) unit) (or (pair address (pair address nat)) (pair address nat)))) (or (or (or (pair address nat) nat) (or address address)) (or (or address unit) (or unit (or address unit))))`
 
 
 
@@ -1630,6 +1567,18 @@ We distinquish several error classes:
   If an internal error is thrown, please report it to the author of this contract.
 
 
+<a name="errors-InternalError"></a>
+
+---
+
+### `InternalError`
+
+**Class:** Internal
+
+**Fires if:** Internal error occured.
+
+**Representation:** Textual error message, see [`Text`](#types-Text).
+
 <a name="errors-SenderIsNotAdmin"></a>
 
 ---
@@ -1679,3 +1628,4 @@ We distinquish several error classes:
 **Representation:** `("UpgVersionMismatch", <error argument>)`.
 
 Provided error argument will be of type (***expected*** : [`Natural`](#types-Natural), ***actual*** : [`Natural`](#types-Natural)).
+

--- a/src/Client/Parser.hs
+++ b/src/Client/Parser.hs
@@ -20,7 +20,7 @@ import Options.Applicative
 import qualified Options.Applicative as Opt
 import qualified Text.Megaparsec as P
   (Parsec, customFailure, many, parse, satisfy)
-import Text.Megaparsec.Char (space, newline)
+import Text.Megaparsec.Char (space, eol)
 import Text.Megaparsec.Char.Lexer (symbol)
 import Text.Megaparsec.Error (ParseErrorBundle, ShowErrorComponent(..))
 
@@ -427,7 +427,7 @@ tezosClientAddressParser :: Parser (Address, PublicKey)
 tezosClientAddressParser = do
   void $ symbol space "Hash:"
   rawAddress <- fromString <$> P.many (P.satisfy isBase58Char)
-  void $ newline
+  void $ eol
   void $ symbol space "Public Key:"
   rawPublicKey <- fromString <$> P.many (P.satisfy isBase58Char)
   case (parseAddress rawAddress, parsePublicKey rawPublicKey) of

--- a/src/Lorentz/Contracts/TZBTC.hs
+++ b/src/Lorentz/Contracts/TZBTC.hs
@@ -36,7 +36,7 @@ import Lorentz.Contracts.TZBTC.V1
 -- Implementation
 ----------------------------------------------------------------------------
 
-tzbtcCompilationWay :: LorentzCompilationWay TZBTCParameter TZBTCStorage
+tzbtcCompilationWay :: (NiceStorage store) => LorentzCompilationWay TZBTCParameter store
 tzbtcCompilationWay = lcwEntryPointsRecursive
 
 toSafeParam :: Parameter a -> Maybe (SafeParameter a)

--- a/src/Lorentz/Contracts/TZBTC/FlatParameter.hs
+++ b/src/Lorentz/Contracts/TZBTC/FlatParameter.hs
@@ -28,7 +28,6 @@ import Lorentz.Contracts.TZBTC.Types
 data FlatParameter interface
   = Run (UParam interface)
   | Upgrade (UpgradeParameters interface)
-  | SetMaster Address
   | EpwBeginUpgrade Natural  -- version
   | EpwApplyMigration MigrationScript
   | EpwSetCode (UContractRouter interface)
@@ -57,7 +56,6 @@ fromFlatParameter :: FlatParameter s -> TZBTC.Parameter s
 fromFlatParameter = \case
   Run a -> TZBTC.SafeEntrypoints $ TZBTC.Run a
   Upgrade a -> TZBTC.SafeEntrypoints $ TZBTC.Upgrade a
-  SetMaster a -> TZBTC.SafeEntrypoints $ TZBTC.SetMaster a
   EpwBeginUpgrade a -> TZBTC.SafeEntrypoints $ TZBTC.EpwBeginUpgrade a
   EpwApplyMigration a -> TZBTC.SafeEntrypoints $ TZBTC.EpwApplyMigration (#migrationscript .! a)
   EpwSetCode a -> TZBTC.SafeEntrypoints $ TZBTC.EpwSetCode (#contractcode .! a)

--- a/src/Lorentz/Contracts/TZBTC/Types.hs
+++ b/src/Lorentz/Contracts/TZBTC/Types.hs
@@ -72,7 +72,6 @@ deriving instance Show MigrationScript
 data SafeParameter (interface :: [EntryPointKind])
   = Run (UParam interface)
   | Upgrade (UpgradeParameters interface)
-  | SetMaster Address
 
   -- Entrypoint-wise upgrades are currently not protected from version mismatch
   -- in subsequent transactions, so the user ought to be careful with them.
@@ -151,8 +150,6 @@ instance Buildable (Parameter s) where
         "Transfer from " +| from |+ " to " +| to |+ ", value = " +| value |+ ""
       Approve (arg #spender -> spender, arg #value -> value) ->
         "Approve for " +| spender |+ ", value = " +| value |+ ""
-      SetMaster addr ->
-        "Set master to " +| addr |+ ""
       Mint (arg #to -> to, arg #value -> value) ->
         "Mint to " +| to |+ ", value = " +| value |+ ""
       Burn (arg #value -> value) ->
@@ -180,7 +177,6 @@ instance Buildable (Parameter s) where
 -- | The concrete fields of the contract
 data StorageFields interface = StorageFields
   { contractRouter  :: UContractRouter interface
-  , master :: Address
   , currentVersion :: Natural
   , migrating :: Bool
   } deriving stock (Generic, Show)

--- a/test.bats
+++ b/test.bats
@@ -135,7 +135,7 @@
 
 @test "invoking tzbtc 'printInitialStorage' command" {
   result="$(stack exec -- tzbtc printInitialStorage --admin-address tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx)"
-  [ "$result" == 'Pair { } (Pair (Pair { CDR; NIL operation; PAIR } "tz1f1S7V2hZJ3mhj47djb5j1saek8c2yB2Cx") (Pair 0 False))' ]
+  [ "$result" == 'Pair { Elt 0x05010000000561646d696e 0x050a000000160000d476acd953eb55d38c398c85c3f53e19b62b167a } (Pair { CDR; NIL operation; PAIR } (Pair 0 False))' ]
 }
 
 @test "invoking 'parseContractParameter' command to parse burn parameter" {

--- a/test/Test/Migration.hs
+++ b/test/Test/Migration.hs
@@ -51,12 +51,6 @@ test_adminCheck = testGroup "TZBTC contract migration endpoints test"
         v0 <- originateContract
         withSender bob $ lCall v0 $ fromFlatParameter $ EpwFinishUpgrade
         validate . Left $ lExpectCustomError_ #senderIsNotAdmin
-
-  , testCase "Test call to `SetMaster` endpoints are only available to master" $
-      integrationalTestExpectation $ do
-        v0 <- originateContract
-        withSender bob $ lCall v0 $ fromFlatParameter $ SetMaster adminAddress
-        validate . Left $ lExpectCustomError_ #senderIsNotAdmin
   ]
 
 -- Test that migration entrypoints check a not migrating status


### PR DESCRIPTION
Problem : Right now the contract has a `master` field, which is part of the concrete
storage, and an `admin` field, which is part of the wrapped `ustore`. `master`
dictates who can do the migration, where as `admin` controls the access to
the domain logic. We have to merge these two into a single field.

Solution : Eliminate the master field, and only have admin
field inside ustore. We will have to change the v0 version to always
have this field in the wrapped ustore. And the upgradeability entry
points will read from this field from `ustore` to access control upgrade
operations.

Tests: Bats tests were modified to include the changed initial storage
in the output of command that prints initial storage.

<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-62

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
