### PR TITLE
[TBTC-63] Fix crossref checker warnings

### DIFF
--- a/ContractDoc.md
+++ b/ContractDoc.md
@@ -71,7 +71,7 @@ Pass resulting value as parameter to the contract.
 
 This entry point is used to get balance in an account.
 
-**Parameter:** [`View`](#types-View) [`Address`](#types-Address) [`Natural`](#types-Natural)
+**Parameter:** [`View`](#types-View) (***owner*** : [`Address`](#types-Address)) [`Natural`](#types-Natural)
 
 <details>
   <summary><b>How to call this entry point</b></summary>
@@ -1374,6 +1374,18 @@ Address primitive.
 
 
 
+<a name="types-BigMap"></a>
+
+---
+
+### `BigMap`
+
+BigMap primitive.
+
+**Final Michelson representation (example):** `BigMap Integer Natural` = `big_map int nat`
+
+
+
 <a name="types-ByteString"></a>
 
 ---
@@ -1410,6 +1422,30 @@ Signed number.
 
 
 
+<a name="types-Lambda"></a>
+
+---
+
+### `Lambda`
+
+`Lambda i o` stands for a sequence of instructions which accepts stack of type `[i]` and returns stack of type `[o]`.
+
+**Final Michelson representation (example):** `Lambda Integer Natural` = `lambda int nat`
+
+
+
+<a name="types-List"></a>
+
+---
+
+### `List`
+
+List primitive.
+
+**Final Michelson representation (example):** `[Integer]` = `list int`
+
+
+
 <a name="types-MigrationScript"></a>
 
 ---
@@ -1424,6 +1460,20 @@ A code which updates storage in order to make in compliant with the new version 
 
 
 
+<a name="types-Named-entry"></a>
+
+---
+
+### `Named entry`
+
+Some entries have names for clarity.
+
+In resulting Michelson names may be mapped to annotations.
+
+**Final Michelson representation (example):** `number: Integer` = `int`
+
+
+
 <a name="types-Natural"></a>
 
 ---
@@ -1433,6 +1483,18 @@ A code which updates storage in order to make in compliant with the new version 
 Unsigned number.
 
 **Final Michelson representation:** `nat`
+
+
+
+<a name="types-Operation"></a>
+
+---
+
+### `Operation`
+
+Operation primitive.
+
+**Final Michelson representation:** `operation`
 
 
 
@@ -1506,6 +1568,20 @@ Parameter dispatching logic, main purpose of this code is to pass control to an 
 **Structure:** ([`Text`](#types-Text), [`ByteString`](#types-ByteString))
 
 **Final Michelson representation:** `pair string bytes`
+
+
+
+<a name="types-Upgradeale-storage"></a>
+
+---
+
+### `Upgradeale storage`
+
+Storage with not hardcoded structure, which allows upgrading the contract in place.
+
+**Structure:** ***unUStore*** :[`BigMap`](#types-BigMap) [`ByteString`](#types-ByteString) [`ByteString`](#types-ByteString)
+
+**Final Michelson representation:** `big_map bytes bytes`
 
 
 

--- a/src/Lorentz/Contracts/TZBTC/Types.hs
+++ b/src/Lorentz/Contracts/TZBTC/Types.hs
@@ -62,7 +62,6 @@ deriving instance Eq (UContractRouter interface)
 deriving instance Show (UContractRouter interface)
 
 deriving instance Eq MigrationScript
-deriving instance Show MigrationScript
 
 ----------------------------------------------------------------------------
 -- Parameter
@@ -96,13 +95,14 @@ data SafeParameter (interface :: [EntryPointKind])
   deriving stock (Eq, Generic, Show)
   deriving anyclass IsoValue
 
-instance TypeHasDoc (SafeParameter interface) where
+instance (Typeable interface) => TypeHasDoc (SafeParameter interface) where
   typeDocName _ = "Parameter.SafeParameter"
   typeDocMdDescription = "Parameter which does not have unsafe arguments, like raw `Contract p` values."
   typeDocMdReference tp =
     customTypeDocMdReference ("Parameter.SafeParameter", DType tp) []
   typeDocHaskellRep = homomorphicTypeDocHaskellRep
   typeDocMichelsonRep = homomorphicTypeDocMichelsonRep
+  typeDocDependencies = genericTypeDocDependencies
 
 -- | The actual parameter of the main TZBTC contract.
 data Parameter (interface :: [EntryPointKind])

--- a/src/Lorentz/Contracts/TZBTC/V0.hs
+++ b/src/Lorentz/Contracts/TZBTC/V0.hs
@@ -25,7 +25,7 @@ import Lorentz
 import Lorentz.Contracts.Upgradeable.Common hiding (Parameter(..), Storage)
 import Michelson.Text
 import qualified Michelson.Typed as T
-import Michelson.Typed.Doc (DComment(..), DDescription(..), contractDocToMarkdown)
+import Michelson.Doc (DComment(..), DDescription(..), contractDocToMarkdown)
 import Util.Markdown
 import Util.TypeLits
 

--- a/src/Lorentz/Contracts/TZBTC/V1.hs
+++ b/src/Lorentz/Contracts/TZBTC/V1.hs
@@ -96,7 +96,7 @@ originationParams addr redeem balances =
 
 -- | Migrations to version 1 before preprocessing.
 migrationScriptsRaw :: OriginationParameters -> [MigrationScript]
-migrationScriptsRaw op = migrateStorage op ++ epwCodeMigrations epwContract
+migrationScriptsRaw op = migrateStorage op : epwCodeMigrations epwContract
 
 epwContract :: EpwContract Interface StoreTemplate
 epwContract = mkEpwContract v1Impl epwFallbackFail
@@ -122,9 +122,9 @@ originationParamsToStoreTemplate OriginationParameters {..} = let
   where
     toLedgerValue i = (#balance .! i, #approvals .! mempty)
 
-migrateStorage :: OriginationParameters -> [MigrationScript]
+migrateStorage :: OriginationParameters -> MigrationScript
 migrateStorage op =
   templateToMigration $ originationParamsToStoreTemplate op
   where
-    templateToMigration :: StoreTemplate -> [MigrationScript]
+    templateToMigration :: StoreTemplate -> MigrationScript
     templateToMigration template = migrationToScript $ fillUStore template

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,7 +12,7 @@ extra-deps:
     https://gitlab.com/morley-framework/morley.git
     # ^ CI cannot use ssh, so we use http clone here
   commit:
-    53a65e7da988f2b58fb6aca1a30477f720e256d1 # master
+    fba24c6271c2ae1ba4b2c956ab3d2e398d22297c  # master
 
   subdirs:
     - .
@@ -33,6 +33,7 @@ extra-deps:
 - base58-bytestring-0.1.0
 - hex-text-0.1.0.0
 - constraints-0.11@sha256:44f80a313d5d4fcfb3c18eb6625dd3db4bb845d5ca8d3b1f62125a4b7241e590
+- pretty-terminal-0.1.0.0@sha256:e9135d86ebb2a8e3aaf5a79088de4628dbd49988388e0fbfc26c5ecb3c399ad9
 # Required by tezos-bake-monitor-lib
 - functor-infix-0.0.5@sha256:cea21a321031f556d7a21b51e049493e7cb78baf64dd63f0d1a36de01c4c735b
 - hashing-0.1.0.1@sha256:98861f16791946cdf28e3c7a6ee9ac8b72d546d6e33c569c7087ef18253294e7


### PR DESCRIPTION
<!--
 - SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 -
 - SPDX-License-Identifier: LicenseRef-Proprietary
 -->

## Description

Right now there are some warning in CI from crossrefverify checker for
contract documentation, that seems to be caused due to missing
information in TypeHasDoc instances. Fix this so that crossverify-checks
pass.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-63

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
