### PR TITLE
[TM-262] Apply optimizer

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -20,11 +20,9 @@ import Util.IO (writeFileUtf8)
 
 import CLI.Parser
 import Lorentz.Contracts.TZBTC
-  ( Parameter, mkEmptyStorageV0, migrationScripts
-  , originationParams, tzbtcContractCode, tzbtcDoc
-  )
+  (Parameter, migrationScripts, mkEmptyStorageV0, originationParams, tzbtcContract,
+  tzbtcContractRouter, tzbtcDoc)
 import Lorentz.Contracts.TZBTC.Test (mkTestScenario)
-import qualified Lorentz.Contracts.TZBTC.V0 as V0
 import Util.Migration
 
 -- Here in main function we will just accept commands from user
@@ -35,7 +33,7 @@ main = do
   cmd <- execParser programInfo
   case cmd of
     CmdPrintContract singleLine mbFilePath ->
-      printContract singleLine mbFilePath V0.tzbtcContract
+      printContract singleLine mbFilePath tzbtcContract
     CmdPrintInitialStorage adminAddress -> do
       putStrLn $ printLorentzValue True (mkEmptyStorageV0 adminAddress)
     CmdPrintDoc mbFilePath ->
@@ -53,7 +51,7 @@ main = do
       (arg #redeemAddress -> redeem)
       (arg #output -> fp) -> do
         (maybe putStrLn writeFileUtf8 fp) $
-          makeMigrationParams version_ tzbtcContractCode $
+          makeMigrationParams version_ tzbtcContractRouter $
             (migrationScripts $ originationParams admin redeem mempty)
   where
     printContract

--- a/src/Lorentz/Contracts/TZBTC.hs
+++ b/src/Lorentz/Contracts/TZBTC.hs
@@ -21,13 +21,14 @@ module Lorentz.Contracts.TZBTC
   , migrationScripts
   , originationParams
   , toSafeParam
-  , tzbtcContractCode
+  , tzbtcContractRouter
   , tzbtcDoc
   ) where
 
 import Lorentz
 
 import Lorentz.Contracts.TZBTC.FlatParameter
+import Lorentz.Contracts.TZBTC.Preprocess
 import Lorentz.Contracts.TZBTC.Types as Types
 import Lorentz.Contracts.TZBTC.V0
 import Lorentz.Contracts.TZBTC.V1

--- a/src/Lorentz/Contracts/TZBTC/Preprocess.hs
+++ b/src/Lorentz/Contracts/TZBTC/Preprocess.hs
@@ -1,0 +1,39 @@
+{- SPDX-FileCopyrightText: 2019 Bitcoin Suisse
+ -
+ - SPDX-License-Identifier: LicenseRef-Proprietary
+ -}
+
+-- | Preprocessing of TZBTC contract. We modify Lorentz code (by
+-- optimizing it) before compiling to Michelson.
+
+module Lorentz.Contracts.TZBTC.Preprocess
+  ( tzbtcContract
+  , tzbtcContractRouter
+  , migrationScripts
+  ) where
+
+import Lorentz
+
+import Michelson.Optimizer (OptimizerConf(..))
+
+import Lorentz.Contracts.TZBTC.Types (OriginationParameters)
+import Lorentz.Contracts.TZBTC.V0
+import Lorentz.Contracts.TZBTC.V1 (migrationScriptsRaw, tzbtcContractRouterRaw)
+import Lorentz.Contracts.Upgradeable.Common.Base
+
+-- | Preprocessed version of V0 contract.
+tzbtcContract :: Contract (Parameter Interface) UStoreV0
+tzbtcContract = preprocess tzbtcContractRaw
+
+-- | Preprocessed version of contract router for V1.
+tzbtcContractRouter :: UContractRouter Interface
+tzbtcContractRouter =
+  UContractRouter . preprocess . unContractCode $ tzbtcContractRouterRaw
+
+-- | Preprocessed migrations for V1.
+migrationScripts :: OriginationParameters -> [MigrationScript]
+migrationScripts op =
+  MigrationScript . preprocess . unMigrationScript <$> migrationScriptsRaw op
+
+preprocess :: inp :-> out -> inp :-> out
+preprocess = optimizeLorentzWithConf (def { gotoValues = True })

--- a/src/Lorentz/Contracts/TZBTC/V0.hs
+++ b/src/Lorentz/Contracts/TZBTC/V0.hs
@@ -11,7 +11,7 @@ module Lorentz.Contracts.TZBTC.V0
   , Storage(..)
   , UStoreV0
   , mkEmptyStorageV0
-  , tzbtcContract
+  , tzbtcContractRaw
   , tzbtcDoc
   ) where
 
@@ -19,16 +19,15 @@ import Prelude hiding (drop, swap, (>>))
 
 import qualified Data.Text as T
 import Data.Vinyl.Derived (Label)
-import Fmt (Buildable (..), fmt)
+import Fmt (Buildable(..), fmt)
 
 import Lorentz
 import Lorentz.Contracts.Upgradeable.Common hiding (Parameter(..), Storage)
 import Michelson.Text
-import Michelson.Typed.Doc
-  (DComment(..), DDescription(..), contractDocToMarkdown)
 import qualified Michelson.Typed as T
-import Util.TypeLits
+import Michelson.Typed.Doc (DComment(..), DDescription(..), contractDocToMarkdown)
 import Util.Markdown
+import Util.TypeLits
 
 import Lorentz.Contracts.TZBTC.Types as Types
 
@@ -153,8 +152,11 @@ safeEntrypoints = entryCase @(SafeParameter Interface) (Proxy @UpgradeableEntryP
   where
     endWithMigration = migrateCode # nil # pair
 
-tzbtcContract :: Contract (Parameter Interface) UStoreV0
-tzbtcContract = do
+-- | Version 0 of TZBTC contract as written in Lorentz.
+-- It generally should not be used because we preprocess it before
+-- actually using. See 'Lorentz.Contracts.TZBTC.Preprocess'.
+tzbtcContractRaw :: Contract (Parameter Interface) UStoreV0
+tzbtcContractRaw = do
   unpair
   entryCase @(Parameter Interface) (Proxy @UpgradeableEntryPointKind)
     ( #cGetVersion /-> do
@@ -203,7 +205,7 @@ tzbtcDoc = contractDocToMarkdown . buildLorentzDoc $ do
     ]
   contractName "TZBTC" $ do
     doc $ DDescription "This contract is implemented using Lorentz language"
-    tzbtcContract
+    tzbtcContractRaw
     fakeCoerce
     clarifyParamBuildingSteps pbsContainedInSafeEntrypoints safeEntrypoints
 

--- a/src/Lorentz/Contracts/TZBTC/V1.hs
+++ b/src/Lorentz/Contracts/TZBTC/V1.hs
@@ -8,11 +8,9 @@
 module Lorentz.Contracts.TZBTC.V1
   ( Interface
   , StoreTemplate(..)
-  , migrationScripts
+  , migrationScriptsRaw
   , originationParams
-  , printContractCode
-  , printMigrationCode
-  , tzbtcContractCode
+  , tzbtcContractRouterRaw
   )
 where
 
@@ -82,8 +80,9 @@ v1Impl = recFromTuple
     -- for almost each method.
     label //==> part = label /==> callPart (part # unpair)
 
-tzbtcContractCode :: UContractRouter Interface
-tzbtcContractCode = epwServe epwContract
+-- | Contract router before preprocessing.
+tzbtcContractRouterRaw :: UContractRouter Interface
+tzbtcContractRouterRaw = epwServe epwContract
 
 originationParams :: Address -> Address -> Map Address Natural -> OriginationParameters
 originationParams addr redeem balances =
@@ -95,8 +94,9 @@ originationParams addr redeem balances =
     , opTokencode = [mt|TZBTC|]
     }
 
-migrationScripts :: OriginationParameters -> [MigrationScript]
-migrationScripts op = migrateStorage op ++ epwCodeMigrations epwContract
+-- | Migrations to version 1 before preprocessing.
+migrationScriptsRaw :: OriginationParameters -> [MigrationScript]
+migrationScriptsRaw op = migrateStorage op ++ epwCodeMigrations epwContract
 
 epwContract :: EpwContract Interface StoreTemplate
 epwContract = mkEpwContract v1Impl epwFallbackFail
@@ -128,9 +128,3 @@ migrateStorage op =
   where
     templateToMigration :: StoreTemplate -> [MigrationScript]
     templateToMigration template = migrationToScript $ fillUStore template
-
-printContractCode :: LText
-printContractCode = printLorentzValue False $ tzbtcContractCode
-
-printMigrationCode :: OriginationParameters -> LText
-printMigrationCode op = printLorentzValue False $ migrationScripts op

--- a/test/Test/Migration.hs
+++ b/test/Test/Migration.hs
@@ -16,9 +16,9 @@ import Util.Named
 import Lorentz hiding (SomeContract)
 import Lorentz.Contracts.TZBTC as TZBTC
 import qualified Lorentz.Contracts.TZBTC.Types as TZBTCTypes
+import Lorentz.Contracts.Upgradeable.Common (UContractRouter, mkUContractRouter)
 import Lorentz.Test.Integrational
 import Lorentz.UStore.Migration
-import Lorentz.Contracts.Upgradeable.Common (UContractRouter, mkUContractRouter)
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
 
@@ -127,7 +127,7 @@ upgradeParams = let
   o = originationParams adminAddress redeemAddress_ mempty
   in ( #newVersion .! 1
      , #migrationScript .! (manualConcatMigrationScripts $ migrationScripts o)
-     , #newCode tzbtcContractCode
+     , #newCode tzbtcContractRouter
      )
 
 -- Some constants

--- a/test/Test/TZBTC.hs
+++ b/test/Test/TZBTC.hs
@@ -19,19 +19,19 @@ module Test.TZBTC
   , originateTzbtcV1ContractRaw
   ) where
 
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (testCase)
-import Test.Tasty.Hspec (testSpec)
-import qualified Data.Set as Set
 import qualified Data.Map as M
+import qualified Data.Set as Set
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.Hspec (testSpec)
+import Test.Tasty.HUnit (testCase)
 
 import Lorentz
-import Lorentz.Contracts.Consumer
-import Lorentz.Test.Integrational
-import Lorentz.UStore.Migration
 import qualified Lorentz.Contracts.ApprovableLedgerInterface as AL
+import Lorentz.Contracts.Consumer
 import Lorentz.Contracts.ManagedLedger.Test
   (ApprovableLedger(..), OriginationParams(..), approvableLedgerSpec, originateManagedLedger)
+import Lorentz.Test.Integrational
+import Lorentz.UStore.Migration
 import Util.Named
 
 import Lorentz.Contracts.TZBTC
@@ -78,7 +78,7 @@ originateTzbtcV1ContractRaw redeem op = do
     upgradeParams =
       ( #newVersion .! 1
       , #migrationScript .! (manualConcatMigrationScripts $ migrationScripts o)
-      , #newCode tzbtcContractCode
+      , #newCode tzbtcContractRouter
       )
   withSender adminAddress $ lCall c (fromFlatParameter $ Upgrade upgradeParams)
   pure c


### PR DESCRIPTION
## Description

Problem: `morley` nowadays has optimizer which makes code smaller and
reduces gas consumption. It is not used in TZBTC yet.

Solution:
* add `Preprocess.hs` module with `preprocess` function which calls
optimizer;
* apply it to all code that constitutes TZBTC contract, export
preprocessed versions from `Preprocess.hs`, use them.

Optimized: https://better-call.dev/babylon/KT1N6g9nr7wy4U4KpnzUzyyD1JWsNn3kWs5x/operations
Non-optimized: https://better-call.dev/babylon/KT1NctD58VH5psA49CSu69YwRXVfRDbtzgZU/operations

You can see that gas consumption decreases a little bit.

## Related issue(s)

https://issues.serokell.io/issue/TM-262

## :white_check_mark: Checklist for your Merge Request

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
