### PR TITLE
[TBTC-70] Fix multisig call

### DIFF
--- a/src/Client/Types.hs
+++ b/src/Client/Types.hs
@@ -10,6 +10,7 @@ module Client.Types
   , ClientConfig
   , ClientConfigPartial
   , ClientConfigText
+  , EntrypointParam(..)
   , ForgeOperation (..)
   , InternalOperation (..)
   , MichelsonExpression (..)
@@ -168,6 +169,10 @@ data BlockConstants = BlockConstants
   { bcProtocol :: Text
   , bcChainId :: Text
   }
+
+data EntrypointParam param
+  = DefaultEntrypoint param
+  | Entrypoint Text param
 
 data RunError
   = RuntimeError Address


### PR DESCRIPTION
## Description

When a multisig action is called using a package with signatures, the client errors out with a wrong parameter error. This seems to be happening because of the new entry point feature of babylon. Since the multisig contract has a default entrypoint, the when the call is made without specifying an entrypoint, it gets routed to the default entrypoint which expects a unit value.

Solution: It seems that the RPC api already provides a way to specify the entrypoint. Use it to call the `main` entrypoint of multisig contract during multisig call.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-70

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
