### PR TITLE
[TBTC-66] Fix setupclient regression

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,5 +1,5 @@
 Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 
-Files: .github/pull_request_template.md
+Files: .github/pull_request_template.md test/resources/*
 Copyright: 2019 Bitcoin Suisse
 License: LicenseRef-Proprietary

--- a/src/Client/Error.hs
+++ b/src/Client/Error.hs
@@ -49,7 +49,8 @@ instance Buildable TzbtcClientError where
     "Invalid client configuration. Use 'tzbtc-client setupClient'"
 
   build (TzbtcClientConfigFileNotFound p) =
-    "Config file was not found at : " +| (build p)
+    "Config file was not found at: " +| (build p) +|
+    ".\nUse 'tzbtc-client setupClient' command to create a sample config file."
 
   build TzbtcMutlisigConfigUnavailable =
     "Multi-sig configuration was not available"

--- a/src/Client/IO/FileSystem.hs
+++ b/src/Client/IO/FileSystem.hs
@@ -1,0 +1,21 @@
+{- SPDX-FileCopyrightText: 2019 Bitcoin Suisse
+ -
+ - SPDX-License-Identifier: LicenseRef-Proprietary
+ -}
+module Client.IO.FileSystem
+  ( getConfigPaths
+  ) where
+
+import System.Environment.XDG.BaseDir (getUserConfigDir, getUserConfigFile)
+
+import Client.Types
+
+appName, configFile :: FilePath
+appName = "tzbtc"
+configFile = "config.json"
+
+getConfigPaths :: IO (DirPath, FilePath)
+getConfigPaths = do
+  configDir <- getUserConfigDir appName
+  configPath <- getUserConfigFile appName configFile
+  pure (DirPath configDir, configPath)

--- a/src/Util/AbstractIO.hs
+++ b/src/Util/AbstractIO.hs
@@ -17,7 +17,6 @@ module Util.AbstractIO
   , HasTezosRpc(..)
   ) where
 
-import Data.Aeson (FromJSON)
 import Options.Applicative as Opt
 
 import Tezos.Address
@@ -36,12 +35,11 @@ class (Monad m) => HasFilesystem m  where
   writeFile :: FilePath -> ByteString -> m ()
   readFile :: FilePath -> m ByteString
   doesFileExist :: FilePath -> m Bool
-  decodeFileStrict :: (FromJSON a) => FilePath -> m (Maybe a)
   createDirectoryIfMissing :: Bool -> DirPath -> m ()
+  getConfigPaths :: m (DirPath, FilePath)
 
 -- Config paths, reads and writes
 class (Monad m, HasFilesystem m) => HasConfig m  where
-  getConfigPaths :: m (DirPath, FilePath)
   readConfig :: m (Either TzbtcClientError ClientConfig)
   readConfigText :: m (Either TzbtcClientError ClientConfigText)
   writeConfigFull :: ClientConfig -> m ()

--- a/test/resources/config-with-required.json
+++ b/test/resources/config-with-required.json
@@ -1,0 +1,9 @@
+{
+    "contract_address": null,
+    "multisig_address": null,
+    "node_address": "localhost",
+    "node_port": 2990,
+    "node_use_https": false,
+    "tezos_client_executable": "tezos-client",
+    "user_alias": "bob"
+}

--- a/test/resources/default-config.json
+++ b/test/resources/default-config.json
@@ -1,0 +1,9 @@
+{
+    "contract_address": "-- Optional field: contract address, Replace this placeholder with proper value or `null` if not required --",
+    "multisig_address": "-- Optional field: multisig contract address, Replace this placeholder with proper value or `null` if not required --",
+    "node_address": "-- Required field: url to the tezos node, Replace this placeholder with proper value --",
+    "node_port": "-- Required field: rpc port of the tezos node, Replace this placeholder with proper value --",
+    "node_use_https": false,
+    "tezos_client_executable": "tezos-client",
+    "user_alias": "-- Required field: user alias, Replace this placeholder with proper value --"
+}


### PR DESCRIPTION
## Description

The `setupClient` command without arguments does not create template correctly for optional value fields. This was fixed by re-including the `ToJSON` instance for `Partial a (Maybe b)` type that overrides the default implementation.

Since the tests for this require changes from TBTC-50 PR, this PR is right now on top of that PR.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-66

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [ ] [README](../blob/master/README.md)
    - [ ] Haddock
    - [ ] [docs/](../blob/master/docs/)
  - [ ] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [ ] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [ ] My code complies with the [style guide](../blob/master/docs/code-style.md).
