### PR TITLE
[Chore] Make documentation link relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Run `stack test` and explore the tests.
 
 ## Contract documentation [↑](#TZBTC)
 
-Contract documentation is located at [TZBTC-contract.md](https://github.com/serokell/tezos-btc/blob/autodoc/master/TZBTC-contract.md).
+Contract documentation is located at [TZBTC-contract.md](../autodoc/master/TZBTC-contract.md).
 
 ## Issue Tracker [↑](#TZBTC)
 


### PR DESCRIPTION
## Description

Problem: documentation link is absolute and does not work in forks.
Solution: make it relative.
It is a bit fragile solution because it relies on GitHub internals
and doesn't work in branches containing `/` in their names.

## Related issue(s)

None

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
