### PR TITLE
[TBTC-73] Fix link to contract documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ Run `stack test` and explore the tests.
 
 ## Contract documentation [↑](#TZBTC)
 
-<!-- TODO TBTC-73 This link is hacky, it only works from the root page!
+<!-- TODO TBTC-73 This link is a bit hacky, it relies on GitHub internals to some extent.
 -->
 
-Contract documentation is located at [TZBTC-contract.md](./blob/autodoc/master/TZBTC-contract.md).
+Contract documentation is located at [TZBTC-contract.md](../autodoc/master/TZBTC-contract.md).
 
 ## Issue Tracker [↑](#TZBTC)
 


### PR DESCRIPTION
## Description

Problem: I changed link to contract documentation to be relative,
but it didn't appear to work at all, even in the root page.

Solution: change the link to be `../BRANCH_NAME`, presumably it will
work. Sadly we can't test it to full extent before merging.

## Related issue(s)

https://issues.serokell.io/issue/TBTC-73

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
