### PR TITLE
[TBTC-80] Remove duplication and include doc from lambdas

### DIFF
--- a/src/Lorentz/Contracts/TZBTC/V0.hs
+++ b/src/Lorentz/Contracts/TZBTC/V0.hs
@@ -30,6 +30,7 @@ import qualified Michelson.Typed as T
 import Util.Markdown
 import Util.TypeLits
 
+import qualified Lorentz.Contracts.TZBTC.Impl as Impl
 import Lorentz.Contracts.TZBTC.Types as Types
 
 -- | Template for the wrapped UStore which will hold the owner address
@@ -108,46 +109,57 @@ safeEntrypoints = entryCase @(SafeParameter Interface StoreTemplateV0) (Proxy @U
   , #cTransfer /-> do
       doc $ DDescription
         "This entry point is used transfer tokens from one account to another."
+      cutLorentzNonDoc (Impl.transfer @(UStore StoreTemplate))
       callUEp #callTransfer
   , #cApprove /-> do
       doc $ DDescription
         "This entry point is used approve transfer of tokens from one account to another."
+      cutLorentzNonDoc (Impl.approve @(UStore StoreTemplate))
       callUEp #callApprove
   , #cMint /-> do
       doc $ DDescription
         "This entry point is used mint new tokes for an account."
+      cutLorentzNonDoc (Impl.mint @(UStore StoreTemplate))
       callUEp #callMint
   , #cBurn /-> do
       doc $ DDescription
         "This entry point is used burn tokes from the redeem address."
+      cutLorentzNonDoc (Impl.burn @(UStore StoreTemplate))
       callUEp #callBurn
   , #cAddOperator /-> do
       doc $ DDescription
         "This entry point is used to add a new operator."
+      cutLorentzNonDoc (Impl.addOperator @(UStore StoreTemplate))
       callUEp #callAddOperator
   , #cRemoveOperator /-> do
       doc $ DDescription
         "This entry point is used to remove an operator."
+      cutLorentzNonDoc (Impl.removeOperator @(UStore StoreTemplate))
       callUEp #callRemoveOperator
   , #cSetRedeemAddress /-> do
       doc $ DDescription
         "This entry point is used to set the redeem address."
+      cutLorentzNonDoc (Impl.setRedeemAddress @(UStore StoreTemplate))
       callUEp #callSetRedeemAddress
   , #cPause /-> do
       doc $ DDescription
         "This entry point is used to pause the contract."
+      cutLorentzNonDoc (Impl.pause @(UStore StoreTemplate))
       callUEp #callPause
   , #cUnpause /-> do
       doc $ DDescription
         "This entry point is used to resume the contract during a paused state."
+      cutLorentzNonDoc (Impl.unpause @(UStore StoreTemplate))
       callUEp #callUnpause
   , #cTransferOwnership /-> do
       doc $ DDescription
         "This entry point is used to transfer ownership to a new owner."
+      cutLorentzNonDoc (Impl.transferOwnership @(UStore StoreTemplate))
       callUEp #callTransferOwnership
   , #cAcceptOwnership /-> do
       doc $ DDescription
         "This entry point is used to accept ownership by a new owner."
+      cutLorentzNonDoc (Impl.acceptOwnership @(UStore StoreTemplate))
       callUEp #callAcceptOwnership
   )
   where
@@ -167,38 +179,47 @@ tzbtcContractRaw = do
     , #cGetAllowance /-> do
         doc $ DDescription
           "This entry point is used to get allowance for an account."
+        cutLorentzNonDoc (Impl.getAllowance @(UStore StoreTemplate))
         callUSafeViewEP #callGetAllowance
     , #cGetBalance /-> do
         doc $ DDescription
           "This entry point is used to get balance in an account."
+        cutLorentzNonDoc (Impl.getBalance @(UStore StoreTemplate))
         callUSafeViewEP #callGetBalance
     , #cGetTotalSupply /-> do
         doc $ DDescription
           "This entry point is used to get total number of tokens."
+        cutLorentzNonDoc (Impl.getTotalSupply @(UStore StoreTemplate))
         callUSafeViewEP #callGetTotalSupply
     , #cGetTotalMinted /-> do
         doc $ DDescription
           "This entry point is used to get total number of minted tokens."
+        cutLorentzNonDoc (Impl.getTotalMinted @(UStore StoreTemplate))
         callUSafeViewEP #callGetTotalMinted
     , #cGetTotalBurned /-> do
         doc $ DDescription
           "This entry point is used to get total number of burned tokens."
+        cutLorentzNonDoc (Impl.getTotalBurned @(UStore StoreTemplate))
         callUSafeViewEP #callGetTotalBurned
     , #cGetOwner /-> do
         doc $ DDescription
           "This entry point is used to get current owner."
+        cutLorentzNonDoc (Impl.getOwner @(UStore StoreTemplate))
         callUSafeViewEP #callGetOwner
     , #cGetTokenName /-> do
         doc $ DDescription
           "This entry point is used to get token name."
+        cutLorentzNonDoc Impl.getTokenName
         callUSafeViewEP #callGetTokenName
     , #cGetTokenCode /-> do
         doc $ DDescription
           "This entry point is used to get token code."
+        cutLorentzNonDoc Impl.getTokenCode
         callUSafeViewEP #callGetTokenCode
     , #cGetRedeemAddress /-> do
         doc $ DDescription
           "This entry point is used to get redeem address."
+        cutLorentzNonDoc (Impl.getRedeemAddress @(UStore StoreTemplate))
         callUSafeViewEP #callGetRedeemAddress
     , #cSafeEntrypoints /-> do
         doc $ DDescription

--- a/src/Lorentz/Contracts/TZBTC/V1.hs
+++ b/src/Lorentz/Contracts/TZBTC/V1.hs
@@ -28,21 +28,15 @@ import Lorentz.Contracts.TZBTC.Types
 
 v1Impl :: Rec (EpwCaseClause StoreTemplate) Interface
 v1Impl = recFromTuple
-  ( #callGetAllowance //==> (toSafeView TZBTC.getAllowance)
-  , #callGetBalance //==> (toSafeView TZBTC.getBalance)
-  , #callGetTotalSupply //==> (toSafeView TZBTC.getTotalSupply)
-  , #callGetTotalMinted //==> (toSafeView $
-      TZBTC.getSingleField #totalMinted "the total number of minted tokens")
-  , #callGetTotalBurned //==> (toSafeView $
-      TZBTC.getSingleField #totalBurned "the total number of burned tokens")
-  , #callGetOwner //==> (toSafeView $
-      TZBTC.getSingleField #owner "the current contract owner")
-  , #callGetTokenName //==> (toSafeView $
-      TZBTC.getSingleField #tokenName "the token name")
-  , #callGetTokenCode //==> (toSafeView $
-      TZBTC.getSingleField #tokenCode "the token code")
-  , #callGetRedeemAddress //==> (toSafeView $
-      TZBTC.getSingleField #redeemAddress "the redeem address")
+  ( #callGetAllowance //==> toSafeView TZBTC.getAllowance
+  , #callGetBalance //==> toSafeView TZBTC.getBalance
+  , #callGetTotalSupply //==> toSafeView TZBTC.getTotalSupply
+  , #callGetTotalMinted //==> toSafeView TZBTC.getTotalMinted
+  , #callGetTotalBurned //==> toSafeView TZBTC.getTotalBurned
+  , #callGetOwner //==> toSafeView TZBTC.getOwner
+  , #callGetTokenName //==> toSafeView TZBTC.getTokenName
+  , #callGetTokenCode //==> toSafeView TZBTC.getTokenCode
+  , #callGetRedeemAddress //==> toSafeView TZBTC.getRedeemAddress
   , #callTransfer //==> TZBTC.transfer
   , #callApprove //==> TZBTC.approve
   , #callMint //==> TZBTC.mint


### PR DESCRIPTION
Problem: In V0.hs we add documentation for each entrypoint (using doc).
Then for some reason we do the same in places where they are implemented
(mostly Impl.hs). But they don't participate in autodoc at all, they are
only used as lambdas during migration. So they can be safely removed.

At the same time we lose some documentation because it is only included
in those lambdas. E. g. you can see that almost all entrypoints can fail
only with UpgContractIsMigrating, but in reality they can fail with
other errors. @Kostya Ivanov suggests using cutLorentzNonDoc for that.

Solution: Remove redundant documentation strings from `Impl.hs` module
and use `cutLorentzNonDoc` function to import doc strings from the
actual implementation for lambda methods.

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-80

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
