### PR TITLE
[TBTC-85] Override default user using --user argument

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,8 @@ Unreleased
 
 0.2.0
 =====
+* [#85] (https://github.com/serokell/tezos-btc/pull/87)
+  - Add global option `--user` to override default `tzbtc-user` user alias
 
 * [#82](https://github.com/serokell/tezos-btc/pull/82)
   - Fix configuration conflict with `tezos-client` config by not having a separate config file.

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ tezos-client add address tzbtc-user tz1RyNvnKnkcD6m9E5VAMxVWVQM5fb9pQo4d --force
 But unfortunately, right now there is [a bug](https://gitlab.com/tezos/tezos/issues/653)
 in `tezos-client` that does not allow adding duplicate alias that point to one of the
 existing aliased address. So instead, you will have to rename the existing alias as
-`tzbtc-user` to use it with `tzbtc-client`. Soon, `tzbtc-client` will be amended to
-include a flag [to override this default user alias.](https://issues.serokell.io/issue/TBTC-85)
+`tzbtc-user` to use it with `tzbtc-client`. Or you can also override the default
+alias `tzbtc-user` using the `--user` argument, in all the commands.
 
 #### Deploy TZBTC contract using `tzbtc-client`
 

--- a/bats/tzbtc-client.bats
+++ b/bats/tzbtc-client.bats
@@ -14,19 +14,40 @@ setup () {
 
 }
 
+@test "invoking tzbtc-client 'approve' command with user" {
+  stack exec -- tzbtc-client approve\
+          --spender "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" --value 100 --dry-run --user john
+
+}
+
 @test "invoking tzbtc-client 'mint' command" {
   stack exec -- tzbtc-client mint\
           --to "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" --value 100 --dry-run
+}
+
+@test "invoking tzbtc-client 'mint' command with user" {
+  stack exec -- tzbtc-client mint\
+          --to "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" --value 100 --dry-run --user john
 }
 
 @test "invoking tzbtc-client 'burn' command" {
   stack exec -- tzbtc-client burn --value 100 --dry-run
 }
 
+@test "invoking tzbtc-client 'burn' command with user" {
+  stack exec -- tzbtc-client burn --value 100 --dry-run --user john
+}
+
 @test "invoking tzbtc-client 'transfer' command" {
   stack exec -- tzbtc-client transfer\
     --to "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"\
     --from "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" --value 100 --dry-run
+}
+
+@test "invoking tzbtc-client 'transfer' command with user" {
+  stack exec -- tzbtc-client transfer\
+    --to "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV"\
+    --from "tz1MuPWVNHwcqLXdJ5UWcjvTHiaAMocaZisx" --value 100 --dry-run --user john
 }
 
 @test "invoking tzbtc-client 'getAllowance' command" {

--- a/client/Main.hs
+++ b/client/Main.hs
@@ -9,4 +9,6 @@ module Main
 import Client.Main
 
 main :: IO ()
-main = mainProgram
+main = do
+  env <- mkInitEnv
+  runAppM env mainProgram

--- a/src/Client/Env.hs
+++ b/src/Client/Env.hs
@@ -1,0 +1,32 @@
+{- SPDX-FileCopyrightText: 2019 Bitcoin Suisse
+ -
+ - SPDX-License-Identifier: LicenseRef-Proprietary
+ -}
+module Client.Env
+  ( AppEnv (..)
+  , AppM
+  , emptyEnv
+  , runAppM
+  ) where
+
+import Client.Error
+import Client.Types
+
+data AppEnv = AppEnv
+  { aeConfigOverride :: ConfigOverride
+  , aeTezosClientPath :: Either TzbtcClientError FilePath
+  }
+
+emptyEnv :: AppEnv
+emptyEnv = AppEnv
+  { aeConfigOverride = emptyConfigOverride
+  , aeTezosClientPath = Left $ TzbtcTezosClientError "Tezos client path not available"
+  }
+
+type AppM = ReaderT AppEnv IO
+
+runAppM :: AppEnv -> AppM a -> IO a
+runAppM = flip runReaderT
+
+emptyConfigOverride :: ConfigOverride
+emptyConfigOverride  = ConfigOverride Nothing

--- a/src/Client/Error.hs
+++ b/src/Client/Error.hs
@@ -10,8 +10,7 @@ import Fmt (Buildable(..), Builder, pretty, (+|), (|+), (+||), (||+))
 import Servant.Client.Core (ClientError(..), Response, ResponseF(..))
 import Servant.Client.Core.Request (RequestF(..))
 import qualified Text.Show (show)
-
-import Tezos.Crypto (CryptoParseError (..))
+import Tezos.Crypto (CryptoParseError(..))
 
 import Client.Types
 

--- a/src/Client/Types.hs
+++ b/src/Client/Types.hs
@@ -3,12 +3,17 @@
  - SPDX-License-Identifier: LicenseRef-Proprietary
  -}
 module Client.Types
-  ( AlmostStorage (..)
+  ( AddrOrAlias
+  , AlmostStorage (..)
   , AppliedResult (..)
   , BlockConstants (..)
-  , ClientConfig(..)
-  , ConfirmationResult(..)
-  , EntrypointParam(..)
+  , ClientArgs (..)
+  , ClientArgsRaw (..)
+  , ClientConfig (..)
+  , ConfirmationResult (..)
+  , ConfigOverride (..)
+  , DeployContractOptions (..)
+  , EntrypointParam (..)
   , ForgeOperation (..)
   , InternalOperation (..)
   , MichelsonExpression (..)
@@ -40,11 +45,57 @@ import Tezos.V005.Micheline
   (Expression(..), MichelinePrimAp(..), MichelinePrimitive(..), annotToText)
 import Tezos.Common.Json (StringEncode(..), TezosInt64)
 
+import Michelson.Text (MText)
 import Michelson.Typed (IsoValue)
 import Tezos.Address (Address)
-import Tezos.Crypto (Signature, encodeBase58Check, formatSignature)
+import Tezos.Crypto (PublicKey, Signature, encodeBase58Check, formatSignature)
 
-import Lorentz.Contracts.TZBTC.Types (StorageFields)
+import Lorentz.Contracts.TZBTC.Types
+
+-- | Client argument with optional dry-run flag
+data ClientArgs = ClientArgs ClientArgsRaw (Maybe AddrOrAlias)  Bool
+
+type AddrOrAlias = Text
+
+data ClientArgsRaw
+  = CmdMint AddrOrAlias Natural (Maybe FilePath)
+  | CmdBurn BurnParams (Maybe FilePath)
+  | CmdTransfer AddrOrAlias AddrOrAlias Natural
+  | CmdApprove AddrOrAlias Natural
+  | CmdGetAllowance (AddrOrAlias, AddrOrAlias) (Maybe AddrOrAlias)
+  | CmdGetBalance AddrOrAlias (Maybe AddrOrAlias)
+  | CmdAddOperator AddrOrAlias (Maybe FilePath)
+  | CmdRemoveOperator AddrOrAlias (Maybe FilePath)
+  | CmdPause (Maybe FilePath)
+  | CmdUnpause (Maybe FilePath)
+  | CmdSetRedeemAddress AddrOrAlias (Maybe FilePath)
+  | CmdTransferOwnership AddrOrAlias (Maybe FilePath)
+  | CmdAcceptOwnership AcceptOwnershipParams
+  | CmdGetTotalSupply (Maybe AddrOrAlias)
+  | CmdGetTotalMinted (Maybe AddrOrAlias)
+  | CmdGetTotalBurned (Maybe AddrOrAlias)
+  | CmdGetOwner (Maybe AddrOrAlias)
+  | CmdGetTokenName (Maybe AddrOrAlias)
+  | CmdGetTokenCode (Maybe AddrOrAlias)
+  | CmdGetRedeemAddress (Maybe AddrOrAlias)
+  | CmdGetOperators
+  | CmdGetOpDescription FilePath
+  | CmdGetBytesToSign FilePath
+  | CmdAddSignature PublicKey Signature FilePath
+  | CmdSignPackage FilePath
+  | CmdCallMultisig (NonEmpty FilePath)
+  | CmdDeployContract !DeployContractOptions
+  | CmdShowConfig
+
+data DeployContractOptions = DeployContractOptions
+  { dcoOwner :: ! (Maybe AddrOrAlias)
+  , dcoRedeem :: !AddrOrAlias
+  , dcoTokenName :: !MText
+  , dcoTokenCode :: !MText
+  }
+
+data ConfigOverride = ConfigOverride
+  { coTzbtcUser :: Maybe AddrOrAlias }
 
 newtype MichelsonExpression = MichelsonExpression Expression
   deriving newtype FromJSON

--- a/src/Util/AbstractIO.hs
+++ b/src/Util/AbstractIO.hs
@@ -26,6 +26,7 @@ import Tezos.V005.Micheline (Expression)
 
 import Client.Error
 import Client.Types
+import Client.Env
 import Lorentz.Constraints
 import Lorentz.Contracts.TZBTC (OriginationParameters)
 
@@ -67,4 +68,5 @@ class (HasConfig m, HasEnv m, Monad m) => HasTezosClient m where
 
 -- Interaction with environment variables
 class (Monad m) => HasEnv m where
-  lookupEnv :: String -> m (Maybe String)
+  lookupEnv :: m AppEnv
+  withLocal :: (AppEnv -> AppEnv) -> m a -> m a


### PR DESCRIPTION
## Description

Problem: We use the `tezos-client` alias `tbtc-user` by default, for sending operations. But sometimes we might need to send transactions as a different user. Right now this is only possible by re-aliasing the `tzbtc-user` alias to the new address. We need to add a way to override the default `tzbtc-user` alias for all commands that send network operations

The PR adds a global option `--user` that accept an address or alias and use it to override the default `tzbtc-user` alias to send network operations.

Internally, this PR replaces the IO monad with a `ReaderT AppEnv IO` where we store the user override information from the command line argument. The `HasConfig` method looks up the override from the environment of the reader, and adjust the value of `userAlias` configuration values accordingly. So the code of the individual commands remains the same, and the changes are restricted mostly to top level code.

Tests: A test has been added in the test suite that checks the output
of config command contains the overridden aliased user. Some Bats tests
were also added to check the existence of `--user` argument.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-85

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
