### PR TITLE
[TBTC-80] Fix redundant doc by not reusing DocItem instance

### DIFF
--- a/src/Lorentz/Contracts/TZBTC/V0.hs
+++ b/src/Lorentz/Contracts/TZBTC/V0.hs
@@ -57,6 +57,9 @@ emptyCode = UContractRouter $ cdr # nil # pair
 -- | Entry point of upgradeable contract.
 data UpgradeableEntryPointKind
 
+-- | Safe entry points of contract.
+data SafeEntryPointKind
+
 instance DocItem (DEntryPoint UpgradeableEntryPointKind) where
   type DocItemPosition (DEntryPoint UpgradeableEntryPointKind) = 1002
   docItemSectionName = Just "Top-level entry points of upgradeable contract."
@@ -64,8 +67,14 @@ instance DocItem (DEntryPoint UpgradeableEntryPointKind) where
     "These are entry points of the contract."
   docItemToMarkdown = diEntryPointToMarkdown
 
+instance DocItem (DEntryPoint SafeEntryPointKind) where
+  type DocItemPosition (DEntryPoint SafeEntryPointKind) = 1003
+  docItemSectionName = Nothing
+  docItemSectionDescription = Nothing
+  docItemToMarkdown = diEntryPointToMarkdown
+
 safeEntrypoints :: Entrypoint (SafeParameter Interface StoreTemplateV0) UStoreV0
-safeEntrypoints = entryCase @(SafeParameter Interface StoreTemplateV0) (Proxy @UpgradeableEntryPointKind)
+safeEntrypoints = entryCase @(SafeParameter Interface StoreTemplateV0) (Proxy @SafeEntryPointKind)
   ( #cRun /-> do
       doc $ DDescription
         "This entry point is used to call the packed entrypoints in the contract."


### PR DESCRIPTION
## Description

Problem: One instance of redundant documentation still remain in
contract doc. This was caused due to a reuse of a DocItem instance.

Solution: Add a new type and implement DocItem instance that removes
the redundant documentation.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-80

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
