### PR TITLE
[Chore] Bump version in release.nix

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -5,6 +5,7 @@
 <<: !include "./hpack/module.yaml"
 
 name:                tzbtc
+# If you update this version, make sure to update it in release.nix
 version:             0.2.0
 
 extra-source-files:

--- a/release.nix
+++ b/release.nix
@@ -11,8 +11,8 @@ let
   packageDesc = {
     project = "tzbtc-client";
     majorVersion = "0";
-    minorVersion = "1";
-    packageRevision = "1";
+    minorVersion = "2";
+    packageRevision = "0";
     bin = "${tzbtc-static}/bin/tzbtc-client";
     arch = "amd64";
     license = "Proprietary";


### PR DESCRIPTION
## Description

Problem: version in package.yaml was bumped to 0.2.0, but
release.nix still defines 0.1.1.

Solution: update release.nix, add a reminder comment to
version in package.yaml.

## Related issue(s)

None
## :white_check_mark: Checklist for your Merge Request

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
