### PR TITLE
[TBTC-50] Small tweak to 'config' command test

### DIFF
--- a/src/Util/AbstractIO.hs
+++ b/src/Util/AbstractIO.hs
@@ -63,7 +63,9 @@ class (HasConfig m, HasEnv m, Monad m) => HasTezosClient m where
   getAddressForContract :: Text -> m (Either TzbtcClientError Address)
   signWithTezosClient :: Either ByteString Text -> Text -> m (Either Text Signature)
   waitForOperation :: Text -> m ()
-  getTezosClientConfig :: m (Either Text (FilePath, TezosClientConfig))
+  getTezosClientConfig ::
+    m (Either Text
+          (FilePath, TezosClientConfig)) -- File path is path to tezos-client executable
   rememberContractAs :: Address -> Text -> m ()
 
 -- Interaction with environment variables


### PR DESCRIPTION
## Description

Change IO test of config command to check that the config entries
returned by the `tezos-client` has been included in the printed config,
along with the overridden user alias.

I hope we can close TBTC-50 with this PR. But If you can think of anything more to be included in these tests, please share. Right now the tests included are

1. Dry run flag

Tests that if `--dry-run` flag is included in command line, no internal operations are called.

2. Multisig package creation

Create a multisig package using `addOperator` operator, and check that the file that is getting written is a legit multisig package with the same operation in it.

3. Signing of Multisig package

Call the `signPackage` command providing mock signature, and checks that the file being written contains the mock signature in it along with the users public key.

4. Creation of Multisig parameter from multiple package files

Call the `callMultisig` command with multiple package files, and provide mocked file contents,
and checks that the `runTransaction` function gets the expected transaction parameters.

5. Overriding of default user alias.

Calls the command to print the active configuration, providing a user override flag, and checks
if the provided user alias appears in the config output. Also checks the tezos-client config values are part of the printed output.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-50

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
