### PR TITLE
[TM-381] Remove redundant field from multisig package record

### DIFF
--- a/src/Client/IO.hs
+++ b/src/Client/IO.hs
@@ -250,7 +250,7 @@ createMultisigPackage packagePath parameter = do
   case ccMultisigAddress of
     Nothing -> throwM TzbtcMutlisigConfigUnavailable
     Just msAddr ->  do
-      ((Counter counter), _) <- getMultisigStorage msAddr config
+      (counter, _) <- getMultisigStorage msAddr config
       case ccContractAddress of
         Nothing -> throwM TzbtcContractConfigUnavailable
         Just (toTAddress -> contractAddr) ->

--- a/test/Test/MultiSig.hs
+++ b/test/Test/MultiSig.hs
@@ -7,7 +7,7 @@ module Test.MultiSig (test_multisig) where
 import qualified Data.Set as Set
 import qualified Data.Text as T (drop)
 import Test.Hspec (Expectation)
-import Test.HUnit (assertBool, assertEqual)
+import Test.HUnit (assertEqual)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (testCase)
 
@@ -263,24 +263,6 @@ test_multisig = testGroup "TZBTC contract multi-sig functionality test"
           "The signatures in multi-sig parameter is in the expected order"
           [Just aliceSig, Nothing, Just carlosSig]
           sigList
-
-  , testCase "Test user is not allowed to sign a bad package" $ do
-      let
-        msig  = TAddress @MSigParameter $
-                unsafeParseAddress "KT19rTTBPeG1JAvrECgoQ8LJj1mJrN7gsdaH"
-        tzbtc = TAddress @(TZBTC.Parameter SomeTZBTCVersion) $
-                unsafeParseAddress "KT1XXJWcjrwfcPL4n3vjmwCBsvkazDt8scYY"
-
-        tzbtcParam = TZBTCTypes.AddOperator (#operator .! operatorAddress)
-        tzbtcParamBadParam = TZBTCTypes.RemoveOperator (#operator .! operatorAddress)
-        package = MSig.mkPackage @(TAddress MSigParameter) msig 0 tzbtc tzbtcParam
-        package2 = MSig.mkPackage @(TAddress MSigParameter) msig 0 tzbtc tzbtcParamBadParam
-
-        -- replace operation with bad operation
-        badPackage = package { pkToSign = pkToSign package2 } :: Package
-        bytesToSign = getBytesToSign package
-        aliceSig = sign_ aliceSK bytesToSign
-      assertBool "User was able to sign bad package" (isLeft $ addSignature badPackage (alicePK, aliceSig))
   ]
 
   where


### PR DESCRIPTION
## Description

Problem: We switched to specialized multisig contract recently. Since the
specialized multisig works by packing the parameter itself in its
payload, the `pkSrcParam` field has become redundant.

Solutuion: Remove this field from package structure. Change code that
shows the operation description, to decode the `pkToSign` field itself.
This has made one test redundant, so have removed that also.

Right now this PR is on top of https://github.com/serokell/tezos-btc/pull/96

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://gitlab.com/morley-framework/morley/issues/67

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
