### PR TITLE
[TBTC-93] Add `--multisig` flag to `acceptOwnership` command

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@ Changes that affect Michelson code are tagged with `[CONTRACT]`.
 
 0.3.0
 =====
+* [#100](https://github.com/serokell/tezos-btc/pull/100)
+  - Add `--multisig` option for `acceptOwnership` tzbtc-client command.
 * [#98](https://github.com/serokell/tezos-btc/pull/98)
   - Further update automated documentation.
 * [#96](https://github.com/serokell/tezos-btc/pull/96)

--- a/bats/tzbtc-client.bats
+++ b/bats/tzbtc-client.bats
@@ -167,6 +167,10 @@ setup () {
   stack exec -- tzbtc-client addOperator --operator "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV" --multisig package.txt --dry-run
 }
 
+@test "invoking multisig package creation for acceptOwnership" {
+  stack exec -- tzbtc-client acceptOwnership --multisig package.txt --dry-run
+}
+
 @test "deploy contract" {
   stack exec -- tzbtc-client deployTzbtcContract --owner boba --redeem boba --token-name Kukareq --token-code Cococoq --dry-run
 }

--- a/src/Client/Main.hs
+++ b/src/Client/Main.hs
@@ -106,8 +106,9 @@ mainProgram = do
           newOwner <- addrOrAliasToAddr newOwner'
           runMultisigTzbtcContract mbMultisig $
             fromFlatParameter $ TransferOwnership (#newOwner .! newOwner)
-        CmdAcceptOwnership p -> runTzbtcContract $
-          fromFlatParameter $ AcceptOwnership p
+        CmdAcceptOwnership p mbMultisig -> do
+          runMultisigTzbtcContract mbMultisig $
+            fromFlatParameter $ AcceptOwnership p
         CmdGetTotalSupply callback -> do
           simpleGetter #totalSupply "Total supply" GetTotalSupply callback
         CmdGetTotalMinted callback -> do

--- a/src/Client/Parser.hs
+++ b/src/Client/Parser.hs
@@ -173,7 +173,7 @@ clientArgRawParser = Opt.hsubparser $
     acceptOwnershipCmd =
       (mkCommandParser
          "acceptOwnership"
-         (pure $ CmdAcceptOwnership ())
+         (CmdAcceptOwnership () <$> multisigOption)
          "Accept ownership")
 
     getTotalSupplyCmd :: Opt.Mod Opt.CommandFields ClientArgsRaw

--- a/src/Client/Types.hs
+++ b/src/Client/Types.hs
@@ -71,7 +71,7 @@ data ClientArgsRaw
   | CmdUnpause (Maybe FilePath)
   | CmdSetRedeemAddress AddrOrAlias (Maybe FilePath)
   | CmdTransferOwnership AddrOrAlias (Maybe FilePath)
-  | CmdAcceptOwnership AcceptOwnershipParams
+  | CmdAcceptOwnership AcceptOwnershipParams (Maybe FilePath)
   | CmdGetTotalSupply (Maybe AddrOrAlias)
   | CmdGetTotalMinted (Maybe AddrOrAlias)
   | CmdGetTotalBurned (Maybe AddrOrAlias)


### PR DESCRIPTION
## Description

Problem: The `acceptOwnership` command of `tzbtc-client` does not accept
a `--multisig` option to create a multisig package for the operation.
Without this, transferring ownership to a multisig contract is
impossible.

Solution: Add the `--multisig` option to the `tzbtc-client` program.


<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-93

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
