### PR TITLE
[TBTC-94] Option to override multisig alias

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,8 @@ Changes that affect Michelson code are tagged with `[CONTRACT]`.
 
 Unreleased
 ==========
+* [#105](https://github.com/serokell/tezos-btc/pull/105)
+  - Add global option "--multisig-addr" to override the default multisig address/alias.
 * [#104](https://github.com/serokell/tezos-btc/pull/104)
   - Updated patched `tezos-client` building.
 * [#99](https://github.com/serokell/tezos-btc/pull/99)

--- a/README.md
+++ b/README.md
@@ -157,9 +157,15 @@ public keys in its storage.
 In order to perform these actions make sure, that multisig contract's address is
 an owner/operator of the TZBTC contract.
 
-All administrative operations can be performed using multisig.
-In order to create multisig package you should provide `--multisig` flag.
-E.g. `tzbtc-client pause --multisig`. This command will return encoded multisig package.
+All administrative operations can be performed using multisig.  In order to
+create a multisig package (a file that holds the contract operation along with
+the signatures) you should provide the path to the package file using the
+`--multisig-package` option. By default this command will use the alias
+`tzbtc-multisig` as the contract alias of the multisig that should be used. But
+you can override this using the `--multisig-addr` option.
+
+E.g. `tzbtc-client pause --multisig-package path-to-package-file`. This command
+will create the encoded multisig package at the specified path.
 
 You can get operation description from this package using `tzbtc-client getOpDescription` command.
 

--- a/bats/tzbtc-client.bats
+++ b/bats/tzbtc-client.bats
@@ -164,11 +164,11 @@ setup () {
 }
 
 @test "invoking multisig package creation" {
-  stack exec -- tzbtc-client addOperator --operator "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV" --multisig package.txt --dry-run
+  stack exec -- tzbtc-client addOperator --operator "tz1UMD9BcyJsiTrPLQSy1yoYzBhKUry66wRV" --multisig-package package.txt --dry-run
 }
 
 @test "invoking multisig package creation for acceptOwnership" {
-  stack exec -- tzbtc-client acceptOwnership --multisig package.txt --dry-run
+  stack exec -- tzbtc-client acceptOwnership --multisig-package package.txt --dry-run
 }
 
 @test "deploy contract" {

--- a/src/Client/Env.hs
+++ b/src/Client/Env.hs
@@ -29,4 +29,4 @@ runAppM :: AppEnv -> AppM a -> IO a
 runAppM = flip runReaderT
 
 emptyConfigOverride :: ConfigOverride
-emptyConfigOverride  = ConfigOverride Nothing
+emptyConfigOverride  = ConfigOverride Nothing Nothing

--- a/src/Client/Main.hs
+++ b/src/Client/Main.hs
@@ -19,7 +19,7 @@ import Lorentz hiding (address, balance, chainId, cons, map)
 import Lorentz.Contracts.Multisig
 import Lorentz.Macro (View(..))
 import Paths_tzbtc (version)
-import Util.Named ((.!))
+import Util.Named
 import Util.TypeLits
 
 import Client.Env
@@ -40,12 +40,18 @@ mainProgram
   , HasCmdLine m
   ) => m ()
 mainProgram = do
-  ClientArgs cmd maybeuser dryRunFlag <- parseCmdLine programInfo
+  ClientArgs cmd
+    (arg #userOverride -> maybeuser)
+    (arg #multisigOverride -> maybemsig) dryRunFlag <- parseCmdLine programInfo
   -- Change the reader environment to include the user alias
   -- override.
-  withLocal (\e -> case maybeuser of
-      Just u -> e { aeConfigOverride = (aeConfigOverride e) { coTzbtcUser = Just u } }
-      Nothing -> e) $ do
+  withLocal (\e ->
+      let
+        override = aeConfigOverride e
+      in e { aeConfigOverride = override
+               { coTzbtcUser = maybeuser
+               , coTzbtcMultisig = maybemsig
+               }}) $ do
     case dryRunFlag of
       True -> pass
       False -> case cmd of

--- a/src/Client/Types.hs
+++ b/src/Client/Types.hs
@@ -49,12 +49,17 @@ import Michelson.Text (MText)
 import Michelson.Typed (IsoValue)
 import Tezos.Address (Address)
 import Tezos.Crypto (PublicKey, Signature, encodeBase58Check, formatSignature)
+import Util.Named
 
 import Lorentz.Contracts.Multisig
 import Lorentz.Contracts.TZBTC.Types
 
 -- | Client argument with optional dry-run flag
-data ClientArgs = ClientArgs ClientArgsRaw (Maybe AddrOrAlias)  Bool
+data ClientArgs =
+  ClientArgs
+    ClientArgsRaw
+      ("userOverride" :! Maybe AddrOrAlias)
+      ("multisigOverride" :! Maybe AddrOrAlias) Bool
 
 type AddrOrAlias = Text
 
@@ -97,7 +102,9 @@ data DeployContractOptions = DeployContractOptions
   }
 
 data ConfigOverride = ConfigOverride
-  { coTzbtcUser :: Maybe AddrOrAlias }
+  { coTzbtcUser :: Maybe AddrOrAlias
+  , coTzbtcMultisig :: Maybe AddrOrAlias
+  } deriving stock Show
 
 newtype MichelsonExpression = MichelsonExpression Expression
   deriving newtype FromJSON


### PR DESCRIPTION
## Description

Problem: Right now tzbtc-client by default uses the alias
`tzbtc-multisig` to get the multisig contract address while creating a
multisig package. But sometimes, we might have to work with more then
one multisig contract, say one for an operator, and another one for an
administrator. There is no easy way to handle this case. User have to
keep renaming the contract they want to use to tzbtc-multisig, before
creating the multisig package.

Solution: Use the config override infra to add this override, and change
`readConfig` function to take it into account while creating the global
config for the application.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-94

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
