### PR TITLE
[TBTC-98] Fix out-of-sync comments

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -30,9 +30,6 @@ import Lorentz.Contracts.TZBTC.Test (smokeTests)
 import Util.AbstractIO
 import Util.Migration
 
--- Here in main function we will just accept commands from user
--- and print the smart contract parameter by using `printLorentzValue`
--- function from Lorentz
 main :: IO ()
 main = do
   cmd <- execParser programInfo

--- a/src/Client/IO.hs
+++ b/src/Client/IO.hs
@@ -322,7 +322,6 @@ type HasStoreTemplateSubmap key value name =
   )
 
 -- | Get field with given name from TZBTC contract UStore.
---
 getFieldFromTzbtcUStore
   :: forall name t m. (HasTezosRpc m, HasStoreTemplateField t name)
   => m (Maybe t)

--- a/test/Test/IO.hs
+++ b/test/Test/IO.hs
@@ -168,7 +168,7 @@ test_dryRunFlag = testGroup "Dry run does not execute any action"
   ]
 
 ---- Test Creation of multisig package. Checks the following.
----- The command is parsed correctely
+---- The command is parsed correctly
 ---- Checks the package is created with the provided parameter
 ---- The replay attack counter is correct
 ---- The multisig address is correct
@@ -235,7 +235,7 @@ test_createMultisigPackage = testGroup "Create multisig package"
     in runMock multiSigCreationTestHandlers test
   ]
 
----- Test multisig contract address override
+-- Test multisig contract address override
 multiSigCreationWithMSigOverrideTestHandlers :: [String] -> Handlers TestM
 multiSigCreationWithMSigOverrideTestHandlers args =
   (defaultHandlers (defaultMockInput { miCmdLine =  args}))
@@ -514,7 +514,7 @@ userOverrideTestHandlers =
       , tcTls = False
       }
 
--- Test user alias gets overrided in config
+-- Test user alias gets overridden in config
 -- if `--user` option is provided.
 -- Also, tests if the config from tezos-client
 -- was included in the printed output.

--- a/test/Test/Migration.hs
+++ b/test/Test/Migration.hs
@@ -30,28 +30,28 @@ originateContract
   :: IntegrationalScenarioM (TAddress (Parameter TZBTCv0))
 originateContract = lOriginate tzbtcContract "TZBTC Contract" (mkEmptyStorageV0 ownerAddress) (toMutez 1000)
 
--- Test that all owneristrative endpoints can only be called as master
+-- Test that all administrative endpoints can only be called as owner
 test_ownerCheck :: TestTree
 test_ownerCheck = testGroup "TZBTC contract migration endpoints test"
-  [  testCase "Test call to owneristrative endpoints are only available to master" $
+  [  testCase "Test call to administrative endpoints are only available to owner" $
       integrationalTestExpectation $ do
         -- Originate a V0 contract
         v0 <- originateContract
         withSender bob $ lCallDef v0 $ fromFlatParameter $ EpwBeginUpgrade (#current .! 0, #new .! 1)
         validate . Left $ lExpectCustomError_ #senderIsNotOwner
-  , testCase "Test call to `ApplyMigration` endpoints are only available to master" $
+  , testCase "Test call to `ApplyMigration` endpoints are only available to owner" $
       integrationalTestExpectation $ do
         v0 <- originateContract
         withSender bob $ lCallDef v0 $ fromFlatParameter $ EpwApplyMigration (checkedCoerce migrationScript)
         validate . Left $ lExpectCustomError_ #senderIsNotOwner
 
-  , testCase "Test call to `SetCode` endpoints are only available to master" $
+  , testCase "Test call to `SetCode` endpoints are only available to owner" $
       integrationalTestExpectation $ do
         v0 <- originateContract
         withSender bob $ lCallDef v0 $ fromFlatParameter $ EpwSetCode emptyCode
         validate . Left $ lExpectCustomError_ #senderIsNotOwner
 
-  , testCase "Test call to `FinishUpgrade` endpoints are only available to master" $
+  , testCase "Test call to `FinishUpgrade` endpoints are only available to owner" $
       integrationalTestExpectation $ do
         v0 <- originateContract
         withSender bob $ lCallDef v0 $ fromFlatParameter $ EpwFinishUpgrade


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

Audit process have uncovered some out of sync comments in the code. So we should fix them.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-89

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
