### PR TITLE
[TBTC-99] Fix calculation of baker fees and add optional argument to explicitly specify it

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@ Unreleased
 * [#113](https://github.com/serokell/tezos-btc/pull/113)
   - Fix baker fee calculation for transactions by using `tezos-client` to compute fees.
   - Add global option "--fee" to explicitly specify baker fees for transactions.
+  - Add global option "--verbose" to enable verbose output.
 * [#108](https://github.com/serokell/tezos-btc/pull/108)
   - Add global option "--contract-addr" to override the default TZBTC contract address/alias.
   - Add option "--dry-run" to `testScenario` command to run the tests using integrational test

--- a/src/Client/Env.hs
+++ b/src/Client/Env.hs
@@ -18,6 +18,7 @@ data AppEnv = AppEnv
   { aeConfigOverride :: ConfigOverride
   , aeTezosClientPath :: Either TzbtcClientError FilePath
   , aeFees :: Maybe TezosInt64
+  , aeVerbose :: Bool
   }
 
 emptyEnv :: AppEnv
@@ -25,6 +26,7 @@ emptyEnv = AppEnv
   { aeConfigOverride = emptyConfigOverride
   , aeTezosClientPath = Left $ TzbtcTezosClientError "Tezos client path not available"
   , aeFees = Nothing
+  , aeVerbose = False
   }
 
 type AppM = ReaderT AppEnv IO

--- a/src/Client/IO/TezosClient.hs
+++ b/src/Client/IO/TezosClient.hs
@@ -17,7 +17,7 @@ module Client.IO.TezosClient
   ) where
 
 import Data.Aeson (eitherDecodeStrict)
-import Data.Text as T (strip, length)
+import Data.Text as T (intercalate, length, strip)
 import Numeric (showFFloat)
 import Servant.Client (ClientEnv, runClientM)
 import Servant.Client.Core as Servant (ClientError(..))
@@ -37,21 +37,18 @@ import Client.Types
 import Client.Util
 
 getTezosClientConfig
-  :: FilePath -> IO (Either Text TezosClientConfig)
-getTezosClientConfig exePath  = do
-  (exitCode, stdout', _stderr') <- readProcessWithExitCode
-    exePath ["config", "show"] ""
-  pure $ case exitCode of
-    ExitSuccess -> let
+  :: Bool -> FilePath -> IO (Either Text TezosClientConfig)
+getTezosClientConfig v exePath  = do
+  callTezosClient v exePath ["config", "show"] Nothing $ \stdout' ->
+    let
       out = strip $ toText stdout'
       -- If the output was empty there was no config file
       -- so return the default tezos-client configuration
-      in if T.length out == 0
-        then pure defTezosConf
-        else case eitherDecodeStrict $ encodeUtf8 $ toText stdout' of
-          Right x -> Right x
-          Left err -> Left $ toText err
-    ExitFailure _ -> Left "Fetching config from `tezos-client` failed"
+    in if T.length out == 0
+      then pure $ Right defTezosConf
+      else case eitherDecodeStrict $ encodeUtf8 $ toText stdout' of
+        Right x -> pure $ Right x
+        Left err -> pure $ Left $ toText err
   where
     defTezosConf = TezosClientConfig
       { tcNodeAddr = "localhost"
@@ -59,67 +56,132 @@ getTezosClientConfig exePath  = do
       , tcTls = False
       }
 
-revealKeyForAlias :: FilePath -> Text -> IO ()
-revealKeyForAlias tcPath alias = do
-  void $ readProcessWithExitCode tcPath
-    ["reveal", "key", "for", toString alias] ""
+-- | Call a program at a given path with the provided arguments. If the
+-- program ran successfully, process the stdout using the first callback, and
+-- return the output as a Right value.  If the program failed, process the
+-- stderr using the second callback, and return the output as a Left value.
+callExe
+  :: forall sPrcs ePrcs. Bool
+  -> FilePath
+  -> [String]
+  -> (Text -> IO sPrcs)
+  -> (Text -> IO ePrcs)
+  -> IO (Either ePrcs sPrcs)
+callExe v exePath args sPrcs ePrcs = do
+  when v $ do
+    putStrLn $ "Executing call:" <> (toText exePath) <> " " <> T.intercalate  " " (toText <$> args)
+  (ec, so, se) <- readProcessWithExitCode exePath args ""
+  when v $ do
+    putStrLn $ "Status:" <> (show ec :: Text)
+    putStrLn $ "Output:" <> so
+    putStrLn $ "Error:" <> se
+  case ec of
+    ExitSuccess -> Right <$> sPrcs (toText so)
+    ExitFailure _ -> Left <$> ePrcs (toText se)
+
+-- | Call `tezos-client` at the provided path with provided args. If optional
+-- burn-cap is provided, include it in the arguments. If the call failed see if
+-- the failure was due to a low burn cap error. If it was, extract the required
+-- burn-cap from the error, and call itself with explicitly specified burn-cap.
+callTezosClient'
+  :: forall sPrcs ePrcs. Bool
+  -> FilePath
+  -> [String]
+  -> Maybe TezosInt64
+  -> (Text -> IO sPrcs)
+  -> (Text -> IO ePrcs)
+  -> IO (Either ePrcs sPrcs)
+callTezosClient' v tcPath args mburnCap sPrcs ePrcs = do
+  case mburnCap of
+    Just bc -> callExe v tcPath (args <> ["--burn-cap", toTezString bc]) sPrcs ePrcs
+    Nothing -> do
+      r <- callExe v tcPath args sPrcs burnCapParser
+      case r of
+        Right rs -> pure (Right rs)
+        Left err -> case err of
+          Right bc ->
+            callTezosClient' v tcPath args (Just $ toMuTez bc) sPrcs ePrcs
+          Left err_ -> Left <$> ePrcs err_
+  where
+    burnCapParser :: Text -> IO (Either Text Double)
+    burnCapParser stderr' = case parseBurncapErrorFromOutput stderr' of
+      Right bc -> pure $ Right bc
+      Left _ -> pure $ Left stderr'
+
+-- | Call tezos-client but throw an error on failure
+callTezosClient
+  :: forall sPrcs. Bool
+  -> FilePath
+  -> [String]
+  -> Maybe TezosInt64
+  -> (Text -> IO sPrcs) -> IO sPrcs
+callTezosClient v tcPath args mburnCap sPrcs = do
+  r <- callTezosClient' v tcPath args mburnCap sPrcs pure
+  case r of
+    Right a -> pure a
+    Left err -> throwM $ TzbtcTezosClientError err
+
+-- | Call tezos-client but return a Nothing on falure
+callTezosClientSafe
+  :: forall sPrcs. Bool
+  -> FilePath
+  -> [String]
+  -> Maybe TezosInt64
+  -> (Text -> IO sPrcs) -> IO (Maybe sPrcs)
+callTezosClientSafe v tcPath args mburnCap sPrcs = do
+  r <- callTezosClient' v tcPath args mburnCap sPrcs pure
+  case r of
+    Right a -> pure $ Just a
+    Left _ -> pure Nothing
+
+parserToCallback :: forall a e. (Show e) => (Text -> Either e a) -> (Text -> IO a)
+parserToCallback fn = \t -> case fn t of
+  Right a -> pure a
+  Left e -> throwM $ TzbtcTezosClientError (show e)
+
+revealKeyForAlias :: Bool -> FilePath -> Text -> IO ()
+revealKeyForAlias v tcPath alias =
+  void $ callTezosClientSafe v tcPath ["reveal", "key", "for", toString alias] Nothing (void . pure)
 
 getAddressAndPKForAlias
-  :: FilePath -> Text -> IO (Either TzbtcClientError (Address, PublicKey))
-getAddressAndPKForAlias tcPath alias  = do
-  (exitCode, stdout', _) <- readProcessWithExitCode tcPath
-    ["show", "address", toString alias] ""
-  case exitCode of
-    ExitSuccess -> do
-      addr <- throwLeft $ pure $ (parseAddressFromOutput $ toText stdout')
-      pure $ Right addr
-    ExitFailure _ -> pure $ Left $ TzbtcUnknownAliasError alias
+  :: Bool -> FilePath -> Text -> IO (Either TzbtcClientError (Address, PublicKey))
+getAddressAndPKForAlias v tcPath alias  = do
+  callTezosClient' v
+    tcPath ["show", "address", toString alias]
+    Nothing (parserToCallback parseAddressFromOutput) (\_ -> pure $ TzbtcUnknownAliasError alias)
 
 getAddressForContract
-  :: FilePath -> Text -> IO (Either TzbtcClientError Address)
-getAddressForContract tcPath alias  = do
-  (exitCode, stdout', _) <- readProcessWithExitCode tcPath
-    ["show", "known", "contract", toString alias] ""
-  case exitCode of
-    ExitSuccess -> do
+  :: Bool -> FilePath -> Text -> IO (Either TzbtcClientError Address)
+getAddressForContract v tcPath alias  = do
+  callTezosClient' v tcPath
+    ["show", "known", "contract", toString alias] Nothing (\stdout' ->
       case parseAddress $ strip $ toText stdout' of
-        Right a -> pure $ Right a
-        Left err -> pure $ Left $ TzbtcParseError (show err)
-    ExitFailure _ -> pure $ Left $ TzbtcUnknownAliasError alias
+        Right a -> pure $ a
+        Left err -> throwM $ TzbtcParseError (show err))
+      (\stderr' -> pure $ TzbtcTezosClientError stderr')
 
-waitForOperationInclusion :: FilePath -> Text -> IO ()
-waitForOperationInclusion tcPath op = do
-  (exitCode, stdout', stderr') <- readProcessWithExitCode tcPath
-    ["wait", "for", toString op, "to", "be", "included"] ""
-  case exitCode of
-    ExitSuccess -> putStr stdout'
-    ExitFailure _ -> putStr stderr'
+waitForOperationInclusion :: Bool -> FilePath -> Text -> IO ()
+waitForOperationInclusion v tcPath op =
+  void $ callTezosClient' v tcPath
+    ["wait", "for", toString op, "to", "be", "included"] Nothing putStr putStr
 
 signWithTezosClient
-  :: FilePath ->  Either InternalByteString Text -> Text -> IO (Either Text Signature)
-signWithTezosClient tcPath bs alias = do
+  :: Bool -> FilePath ->  Either InternalByteString Text -> Text -> IO (Either Text Signature)
+signWithTezosClient v tcPath bs alias = do
   let toSign = case bs of
         Left rawBS -> addTezosBytesPrefix $ formatByteString rawBS
         Right formatedBS -> formatedBS
-  (exitCode, stdout', stderr') <- readProcessWithExitCode tcPath
+  callTezosClient' v tcPath
     [ "sign", "bytes", toString $ toSign
     , "for", toString alias
-    ] ""
-  case exitCode of
-    ExitSuccess -> do
-      Right <$> (throwLeft $ pure $ parseSignatureFromOutput (fromString stdout'))
-    ExitFailure _ -> return . Left . fromString $
-      "Operation signing failed: " <> stderr'
+    ] Nothing (parserToCallback parseSignatureFromOutput) (\stderr' -> pure $ "Operation signing failed: " <> stderr')
 
 rememberContractAs
-  :: FilePath -> Address -> Text -> IO ()
-rememberContractAs tcPath addr alias = do
-  (exitCode, _, stderr') <- readProcessWithExitCode tcPath
-    [ "remember", "contract", toString $ alias , toString $ formatAddress addr, "--force"] ""
-  case exitCode of
-    ExitSuccess -> pass
-    ExitFailure _ -> throwM (TzbtcTezosClientError
-      $ "There was an error in saving the contract alias" <> toText stderr')
+  :: Bool -> FilePath -> Address -> Text -> IO ()
+rememberContractAs v tcPath addr alias =
+  callTezosClient v tcPath
+    [ "remember", "contract", toString $ alias , toString $ formatAddress addr, "--force"]
+    Nothing (void . pure)
 
 -- | Dry run a transaction using 'tezos-client' and extract the expected baker fees
 -- from the output. If the command fails due to a low 'burn-cap' detect it and parse
@@ -127,61 +189,37 @@ rememberContractAs tcPath addr alias = do
 -- the optional 'burn-cap' arugment.
 simulateTransaction
   :: (NicePrintedValue param)
-  => ClientConfig
+  => Bool
+  -> ClientConfig
   -> Maybe TezosInt64 -- burn cap
   -> Address
   -> EntrypointParam param
-  -> IO (Either TzbtcClientError SimulationResult)
-simulateTransaction config mbbc_ addr arg_ = simulateTransaction_ mbbc_
-  where
-    simulateTransaction_ mbbc = do
-      let epArgs = case arg_ of
-            DefaultEntrypoint p -> ["--arg", toString (printLorentzValue True p)]
-            Entrypoint n p ->
-              ["--arg", toString (printLorentzValue True p), "--entrypoint", toString n]
-          bcArgs = case mbbc of
-            Just bc -> ["--burn-cap", toTezString bc]
-            Nothing -> []
-      let args = ([ "transfer", "0.0", "from", (toString $ ccUserAlias config)
-                  , "to",  toString $ formatAddress addr ] <> epArgs <> bcArgs <> ["-D"])
-      (exitCode, stdout', stderr') <- readProcessWithExitCode (ccTezosClientExecutable config)
-        args ""
-      case exitCode of
-        ExitSuccess -> do
-          Right <$> (throwLeft $ pure $ parseSimulationResultFromOutput (fromString stdout'))
-        ExitFailure _ -> case parseBurncapErrorFromOutput (fromString stderr') of
-          Right p -> simulateTransaction_ (Just p)
-          Left _ -> throwM (TzbtcTezosClientError $
-            "There was an error in simulating the transaction:" <> (show args) <> "\nError:" <> toText stderr')
+  -> IO SimulationResult
+simulateTransaction v config mbbc_ addr arg_ = do
+  let epArgs = case arg_ of
+        DefaultEntrypoint p -> ["--arg", toString (printLorentzValue True p)]
+        Entrypoint n p ->
+          ["--arg", toString (printLorentzValue True p), "--entrypoint", toString n]
+  let args = ([ "transfer", "0.0", "from", (toString $ ccUserAlias config)
+              , "to",  toString $ formatAddress addr ] <> epArgs <> ["-D"])
+  callTezosClient v (ccTezosClientExecutable config) args mbbc_ (parserToCallback parseSimulationResultFromOutput)
 
 -- Same as above, but for origination
 simulateOrigination
   :: (NiceParameterFull param, NiceStorage st)
-  => ClientConfig
+  => Bool
+  -> ClientConfig
   -> Maybe TezosInt64 -- burn cap
   -> ContractCode param st
   -> st
-  -> IO (Either TzbtcClientError SimulationResult)
-simulateOrigination config mbbc_ contract_ initst = simulateOrigination_ mbbc_
-  where
-    simulateOrigination_ mbbc = do
-      let bcArgs = case mbbc of
-            Just bc -> ["--burn-cap", toTezString bc]
-            Nothing -> []
-      let args = ([ "originate", "contract", "-", "transferring", "0.0", "from", (toString $ ccUserAlias config)
-                  , "running"
-                  , toString $ printLorentzContract True contract_
-                  , "--init", toString $ printLorentzValue True initst
-                  ] <> bcArgs <> ["-D", "--force"])
-      (exitCode, stdout', stderr') <- readProcessWithExitCode (ccTezosClientExecutable config) args ""
-      case exitCode of
-        ExitSuccess -> do
-          Right <$> (throwLeft $ pure $ parseSimulationResultFromOutput (fromString stdout'))
-        ExitFailure _ -> case parseBurncapErrorFromOutput (fromString stderr') of
-          Right p -> do
-            simulateOrigination_ (Just p)
-          Left _ -> throwM (TzbtcTezosClientError $
-            "There was an error in simulating the transaction:" <> (show args) <> "\nError:" <> toText stderr')
+  -> IO SimulationResult
+simulateOrigination v config mbbc_ contract_ initst = do
+  let args = ([ "originate", "contract", "-", "transferring", "0.0", "from", (toString $ ccUserAlias config)
+              , "running"
+              , toString $ printLorentzContract True contract_
+              , "--init", toString $ printLorentzValue True initst
+              ] <> ["-D", "--force"])
+  callTezosClient v (ccTezosClientExecutable config) args mbbc_ (parserToCallback parseSimulationResultFromOutput)
 
 toTezString :: TezosInt64 -> String
 toTezString x = showFFloat Nothing ((realToFrac x :: Double)/10e6) ""

--- a/src/Client/Main.hs
+++ b/src/Client/Main.hs
@@ -44,6 +44,7 @@ mainProgram = do
     (arg #multisigOverride -> maybemsig)
     (arg #contractOverride -> maybecontract)
     (arg #fee -> maybefees)
+    (arg #verbose -> verbosity)
     dryRunFlag <- parseCmdLine programInfo
   -- Change the reader environment to include the user alias
   -- override.
@@ -56,6 +57,7 @@ mainProgram = do
                , coTzbtcContract = maybecontract
                }
            , aeFees = maybefees
+           , aeVerbose = verbosity
            }) $ do
     case dryRunFlag of
       True -> pass

--- a/src/Client/Types.hs
+++ b/src/Client/Types.hs
@@ -63,6 +63,7 @@ data ClientArgs =
       ("multisigOverride" :! Maybe AddrOrAlias)
       ("contractOverride" :! Maybe AddrOrAlias)
       ("fee" :! Maybe TezosInt64)
+      ("verbose" :! Bool)
       Bool
 
 type AddrOrAlias = Text
@@ -304,7 +305,7 @@ data AppliedResult = AppliedResult
   } deriving Show
 
 data SimulationResult = SimulationResult
-  { srComputedFees :: TezosInt64 -- Baker Fee in micro tez
+  { srComputedFees :: TezosInt64 -- ^ Baker Fee in micro tez
   } deriving Show
 
 instance Semigroup AppliedResult where

--- a/src/Client/Util.hs
+++ b/src/Client/Util.hs
@@ -4,7 +4,6 @@
  -}
 module Client.Util
   ( addTezosBytesPrefix
-  , calcFees
   , exprToValue
   , mkOriginationScript
   , nicePackedValueToExpression
@@ -21,7 +20,6 @@ import Data.Sequence (fromList)
 import Data.Singletons (SingI)
 import Servant.Client.Core (ClientError)
 import Tezos.Common.Binary (decode, encode)
-import Tezos.Common.Json (TezosInt64)
 import Tezos.V005.Micheline (Expression(..), MichelinePrimAp(..), MichelinePrimitive(..))
 
 import Lorentz (ContractCode, compileLorentzContract)
@@ -75,18 +73,6 @@ mkOriginationScript contract storage = OriginationScript
   }
   where
     compiledContract = compileLorentzContract contract
-
-calcFees :: TezosInt64 -> TezosInt64 -> TezosInt64
-calcFees consumedGas storageSize =
-  minimalFees +
-  (computeFeesForGas consumedGas) +
-  minimalTezPerStorage * storageSize
-  where
-    minimalFees = 100
-    computeFeesForGas gas = div ((gas + 100) + 9) 10
-      -- Assuming tez per unit of gas to be 0.1 MuTez
-      -- this is essentially doing (ceiling $ gas * 0.1)
-    minimalTezPerStorage = 10
 
 throwClientError :: MonadThrow m => m (Either ClientError a) -> m a
 throwClientError =

--- a/src/Util/AbstractIO.hs
+++ b/src/Util/AbstractIO.hs
@@ -55,7 +55,11 @@ class (Monad m) => HasCmdLine m where
 class (HasTezosClient m, HasConfig m, Monad m, MonadThrow m) => HasTezosRpc m where
   runTransaction
     :: (NicePackedValue param)
-    => Address -> (EntrypointParam param, TezosInt64) -> Maybe TezosInt64 -> m ()
+    => Address
+    -> EntrypointParam param
+    -> TezosInt64 -- ^ Amount to transfer
+    -> Maybe TezosInt64 -- ^ Optional baker fee to pay.
+    -> m ()
   getStorage :: Text -> m Expression
   getCounter :: Text -> m TezosInt64
   getFromBigMap :: Natural -> Text -> m (Either TzbtcClientError Expression)

--- a/test/Test/IO.hs
+++ b/test/Test/IO.hs
@@ -70,7 +70,7 @@ defaultHandlers mi = Handlers
   , hPrintTextLn = \_ -> meetExpectation PrintsMessage
   , hPrintByteString = \bs -> meetExpectation (PrintByteString bs)
   , hConfirmAction = \_ -> unavailable "confirmAction"
-  , hRunTransactions = \_ _ _ -> unavailable "runTransactions"
+  , hRunTransactions = \_ _ _ _ -> unavailable "runTransactions"
   , hGetStorage = \_ -> unavailable "getStorage"
   , hGetCounter = \_ -> unavailable "getCounter"
   , hGetFromBigMap = \_ _ -> unavailable "getFromBigMap"
@@ -178,7 +178,7 @@ multiSigCreationTestHandlers :: Handlers TestM
 multiSigCreationTestHandlers =
   (defaultHandlers (defaultMockInput { miCmdLine =  args}))
     { hReadFile = \_ -> throwM $ TestError "Unexpected file read"
-    , hRunTransactions = \_ _ _ -> throwM $ TestError "Unexpected `runTransactions` call"
+    , hRunTransactions = \_ _ _ _ -> throwM $ TestError "Unexpected `runTransactions` call"
     , hGetTezosClientConfig = pure $ Right ("tezos-client", cc)
     , hGetAddressForContract = \ca ->
         if ca == "tzbtc"
@@ -241,7 +241,7 @@ multiSigCreationWithMSigOverrideTestHandlers :: [String] -> Handlers TestM
 multiSigCreationWithMSigOverrideTestHandlers args =
   (defaultHandlers (defaultMockInput { miCmdLine =  args}))
     { hReadFile = \_ -> throwM $ TestError "Unexpected file read"
-    , hRunTransactions = \_ _ _ -> throwM $ TestError "Unexpected `runTransactions` call"
+    , hRunTransactions = \_ _ _ _ -> throwM $ TestError "Unexpected `runTransactions` call"
     , hGetTezosClientConfig = pure $ Right ("tezos-client", cc)
     , hGetAddressForContract = \ca ->
         if ca == "tzbtc"
@@ -396,9 +396,9 @@ test_multisigSignPackage = testGroup "Sign multisig package"
 multisigExecutionTestHandlers :: Handlers TestM
 multisigExecutionTestHandlers =
   (defaultHandlers (defaultMockInput { miCmdLine =  args}))
-    { hRunTransactions =  \addr params _ ->
+    { hRunTransactions =  \addr params amount _ ->
         if addr == multiSigAddress then do
-          case params of
+          case (params, amount) of
             (Entrypoint "mainParameter" param, 0) -> do
               case Typ.cast (toVal param) of
                 Just param' -> case (fromVal param') of
@@ -544,7 +544,7 @@ feesAndContractAddrTestHandlers =
         "tzbtc-multisig" -> pure $ Left (TzbtcUnknownAliasError "tzbtc")
         ca -> throwM $ TestError $ "Unexpected contract alias:" ++ (toString ca)
 
-    , hRunTransactions =  \_ _ fees ->
+    , hRunTransactions =  \_ _ _ fees ->
         -- Fees specified as fractional tezos value will be
         -- converted as a mutez value, so we expect 0.00123 * 10e6 here
         if fees == Just 12300 then meetExpectation RunsTransaction else

--- a/test/TestM.hs
+++ b/test/TestM.hs
@@ -91,7 +91,7 @@ data Handlers m = Handlers
 
   , hRunTransactions
     :: forall param. (NicePackedValue param)
-    => Address  -> (EntrypointParam param, TezosInt64) -> Maybe TezosInt64 ->  m ()
+    => Address  -> EntrypointParam param -> TezosInt64 -> Maybe TezosInt64 ->  m ()
   , hGetStorage :: Text -> m Expression
   , hGetCounter :: Text -> m TezosInt64
   , hGetFromBigMap :: Natural -> Text -> m (Either TzbtcClientError Expression)
@@ -144,9 +144,9 @@ instance HasCmdLine TestM where
     fn i
 
 instance HasTezosRpc TestM where
-  runTransaction a b f = do
+  runTransaction a b c f = do
     fn <- getHandler hRunTransactions
-    fn a b f
+    fn a b c f
   getStorage t = do
     fn <- getHandler hGetStorage
     fn t


### PR DESCRIPTION
## Description

Problem: Our calculation of baker fees was slightly wrong, causing the `tzbtc-client` program to spend more credit on fees than it was required. So this PR,

1. Fixes the fees calculation, to match what is being currently done by `tezos-client`.
2. Add a global `--fees` argument, which will be added to the programs execution environment and thus applied to all transactions initiated by the program.

@gromakovsky I was not able to find a way to extract the fees either using the API (Mostly looked at the `pre-apply` api call) or using the `tezos-client`. From the code of the `tezos-client` [1] [2] it seems that it also have a hard coded way to estimate the `--fees`

[1] https://gitlab.com/tezos/tezos/blob/366f64f3df266cf02a06412d6760f73626d0a2bf/src/proto_003_PsddFKi3/lib_client/injection.ml
[2] https://gitlab.com/tezos/tezos/-/blob/366f64f3df266cf02a06412d6760f73626d0a2bf/src/proto_003_PsddFKi3/lib_client/client_proto_args.ml#L252

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-99

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
