### PR TITLE
[TBTC-103] Update `upload-autodoc.sh` script

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,7 +16,7 @@ For example
 Write 'None' if there are no related issues (which is discouraged).
 -->
 
-https://issues.serokell.io/issue/TBTC-
+Resolves #
 
 ## :white_check_mark: Checklist for your Merge Request
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 # TZBTC
 
+[![Build status](https://badge.buildkite.com/aecd40f89a7a0f1b78495ee2afc40ec575de85e18d42116186.svg?branch=master)](https://buildkite.com/serokell/tezos-btc)
+
 Wrapped Bitcoin on Tezos Blockchain called TZBTC
 
 ## Prerequisites

--- a/scripts/ci/upload-autodoc.sh
+++ b/scripts/ci/upload-autodoc.sh
@@ -9,7 +9,7 @@ set -e -o pipefail
 git config --global user.email "hi@serokell.io"
 git config --global user.name "CI autodoc generator"
 git remote remove auth-origin 2> /dev/null || :
-git remote add auth-origin https://serokell:$(cat ~/.config/serokell-bot-token)@github.com/tz-wrapped/tezos-btc.git
+git remote add auth-origin https://serokell:$GITHUB_TOKEN@github.com/tz-wrapped/tezos-btc.git
 git fetch
 
 our_branch="$BUILDKITE_BRANCH"


### PR DESCRIPTION
## Description

Problem: we have updated our infrastructure so that now CI
stores auth toke in the `$GITHUB_TOKEN` variable.

Solution: update the script to use this variable.


## Related issue(s)

https://issues.serokell.io/issue/TBTC-103

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
