### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,15 @@ If you want to use `tzbtc-client` on MacOS, you can try [building it from source
 
 In order to use `tzbtc-client` you will need to obtain `tezos-client`
 executable. `tezos-client` is used for key storing, operation signing and ledger interaction.
-For now, `tezos-client` doesn't support packed value signing via ledger,
-so in order to fully use `tzbtc-client` (perform multisig package signing via ledger)
+
+Tezos ledger application supports packed value signing since [v2.2.7](https://github.com/obsidiansystems/ledger-app-tezos/releases/tag/v2.2.7).
+Note, that this version isn't presented in Ledger Live yet, so you'll have to install it
+to your ledger device manually, the process of manual installation is described
+[here](https://github.com/obsidiansystems/ledger-app-tezos#installing-the-apps-onto-your-ledger-device-without-ledger-live).
+If you have this version installed, you can use non-patched `tezos-client` binary with `tzbtc-client`.
+Various forms of distribution for `tezos-client` are presented in [tezos-packaging repo](https://github.com/serokell/tezos-packaging).
+
+Otherwise in order to fully use `tzbtc-client` (perform multisig package signing via ledger)
 you should use patched `tezos-client` binary. This binary is bundled along
 with `tzbtc-client` in the [releases](https://github.com/tz-wrapped/tezos-btc/releases).
 


### PR DESCRIPTION
## Description
Problem: Ledger app now (since v2.2.7) supports packed value
signing, so non-patched tezos-client can be used as a prerequisite
for `tzbtc-client`, however newest version isn't presented in Ledger
Live.

Solution: Mention this fact in the readme, provide links for downloading new
ledger app and installing it on the ledger device.

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

https://issues.serokell.io/issue/TBTC-106

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
