### PR TITLE
[#139] Increase precision of burn cap

### DIFF
--- a/src/Client/IO/TezosClient.hs
+++ b/src/Client/IO/TezosClient.hs
@@ -222,7 +222,7 @@ simulateOrigination v config mbbc_ contract_ initst = do
   callTezosClient v (ccTezosClientExecutable config) args mbbc_ (parserToCallback parseSimulationResultFromOutput)
 
 toTezString :: TezosInt64 -> String
-toTezString x = formatScientific Fixed (Just 3) ((realToFrac x :: Scientific) / 10e6)
+toTezString x = formatScientific Fixed (Just 6) ((realToFrac x :: Scientific) / 10e6)
 
 getOperationHex
   :: ClientEnv -> ForgeOperation

--- a/test/Test/Client.hs
+++ b/test/Test/Client.hs
@@ -149,14 +149,14 @@ test_addressParser = testGroup "Test parsing tezos-client output"
 
 burnFeeRoundTrip :: Positive Double -> Bool
 burnFeeRoundTrip d = let
-  inpString = showFFloat (Just 3) (getPositive d) ""
+  inpString = showFFloat (Just 6) (getPositive d) ""
   in case parseBurncapErrorFromOutput ("The operation will burn " <> (toText inpString)) of
     Right bc -> (toTezString $ toMuTez bc) == inpString
     Left _ -> False
 
 bakerFeeRoundTrip :: Positive Double -> Bool
 bakerFeeRoundTrip d = let
-  inpString = showFFloat (Just 3) (getPositive d) ""
+  inpString = showFFloat (Just 6) (getPositive d) ""
   in case parseSimulationResultFromOutput ("Fee to the baker: " <> (toText inpString) <> "\n") of
     Right sr -> (toTezString $ srComputedFees sr) == inpString
     Left _ -> False


### PR DESCRIPTION

## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: we print always burn cap with precision set to 3.
It used to work before Delphi where the smallest possible
burn cap was divided by 4. So in some cases we print smaller
burn cap than required.

Solution: increase precision to 6.
It's a temporary solution, we should switch to morley-client
instead and we will do it soon.
For this reason I am not adding any tests.
Hardcoding this precision doesn't sound like a good long term solution
btw, but again, it's temporary.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #139 

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

No tests because it's a temporary fix.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

I don't mention it in the changelog hoping that most people didn't notice this problem :)

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
