### PR TITLE
[#138] New tzbtc release

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,9 @@ Changes that affect Michelson code are tagged with `[CONTRACT]`.
 
 Unreleased
 ==========
+
+0.6.0
+==========
 * [#134](https://github.com/tz-wrapped/tezos-btc/pull/134)
   + `migrate` command of the executable now accepts version differently.
     Instead of

--- a/package.yaml
+++ b/package.yaml
@@ -6,7 +6,7 @@
 
 name:                tzbtc
 # If you update this version, make sure to update it in release.nix
-version:             0.5.0
+version:             0.6.0
 
 extra-source-files:
 - README.md

--- a/release.nix
+++ b/release.nix
@@ -11,7 +11,7 @@ let
   packageDesc = {
     project = "tzbtc-client";
     majorVersion = "0";
-    minorVersion = "5";
+    minorVersion = "6";
     packageRevision = "0";
     bin = "${tzbtc-static}/bin/tzbtc-client";
     arch = "amd64";


### PR DESCRIPTION
## Description
We haven't updated tzbtc releases quite a while. Latest release contains mentions of patched `tezos-client`.
We've dropped the requirement for patched tezos-client long time ago, also we've been updating tzbtc quite
intensively last time, so it's time for a new release
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves part of #138 (automatization is left for another PR)

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
