### PR TITLE
[#123] Port smoke tests to cleveland

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2019 Bitcoin Suisse
 # SPDX-License-Identifier: LicenseRef-MIT-BitcoinSuisse
 
+env:
+  TEZOS_CLIENT_UNSAFE_DISABLE_DISCLAIMER: "Y"
+
 steps:
   - label: hlint
     branches: "!autodoc/master"
@@ -33,9 +36,14 @@ steps:
 
   - label: test
     branches: "!autodoc/master"
-    commands:
+    env:
+      TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8735"
+      TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk3D3Gx5q6mVL4jCAuFCoekWjM6hzrmSA3MCtDUnMAjxmxJ2rtes"
+    commands: &run-test
     - nix-build ci.nix -A tzbtc.components.tests.tzbtc-test
-    - ./result/bin/tzbtc-test
+    # Emulated environment + 007 local-chain
+    - export TASTY_NETTEST_DATA_DIR="$(mktemp -d --tmpdir="$PWD")"
+    - nix run -f ci.nix tezos-client tzbtc.components.exes.tzbtc-client -c ./result/bin/tzbtc-test --nettest-run-network
 
   - label: weeder
     branches: "!autodoc/master"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,36 +6,37 @@ env:
 
 steps:
   - label: hlint
-    branches: "!autodoc/master"
+    if: &not_scheduled_autodoc
+      build.branch != "autodoc/master" && build.branch != "master" && build.source != "schedule"
     commands:
     - nix run -f ci.nix pkgs.hlint -c
         ./scripts/lint.sh
 
   - label: reuse lint
-    branches: "!autodoc/master"
+    if: *not_scheduled_autodoc
     commands:
     - nix run -f ci.nix pkgs.reuse -c
         reuse lint
 
   - label: check trailing whitespace
-    branches: "!autodoc/master"
+    if: *not_scheduled_autodoc
     commands:
     - .buildkite/check-trailing-whitespace.sh
 
   - label: crossref-verify
-    branches: "!autodoc/master"
+    if: *not_scheduled_autodoc
     commands:
     - nix run -f ci.nix crossref-verifier -c
         crossref-verify --mode local-only --config ./.crossref-verifier.yaml
     soft_fail: true  # TODO: remove
 
   - label: build
-    branches: "!autodoc/master"
+    if: *not_scheduled_autodoc
     commands:
     - nix-build ci.nix -A all-components
 
   - label: test
-    branches: "!autodoc/master"
+    if: *not_scheduled_autodoc
     env:
       TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8735"
       TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk3D3Gx5q6mVL4jCAuFCoekWjM6hzrmSA3MCtDUnMAjxmxJ2rtes"
@@ -45,8 +46,22 @@ steps:
     - export TASTY_NETTEST_DATA_DIR="$(mktemp -d --tmpdir="$PWD")"
     - nix run -f ci.nix tezos-client tzbtc.components.exes.tzbtc-client -c ./result/bin/tzbtc-test --nettest-run-network
 
+  - label: scheduled delphinet test
+    if: build.source == "schedule"
+    # use another agent for long scheduled jobs
+    agents:
+      queue: "scheduled"
+    env:
+      TASTY_NETTEST_NODE_ENDPOINT: "http://delphi.testnet.tezos.serokell.team:8732"
+      TASTY_NETTEST_IMPORT_SECRET_KEY: "unencrypted:edsk3D3Gx5q6mVL4jCAuFCoekWjM6hzrmSA3MCtDUnMAjxmxJ2rtes"
+    commands: *run-test
+    retry:
+      automatic:
+        limit: 1
+    timeout_in_minutes: 150
+
   - label: weeder
-    branches: "!autodoc/master"
+    if: *not_scheduled_autodoc
     commands:
     - nix-build ci.nix -A weeder-script
       # weeder needs .cabal file:
@@ -54,7 +69,7 @@ steps:
     - ./result
 
   - label: bats
-    branches: "!autodoc/master"
+    if: *not_scheduled_autodoc
     commands:
     - nix run -f ci.nix pkgs.bats tzbtc.components.exes.tzbtc
         -c bats bats/tzbtc.bats
@@ -62,7 +77,7 @@ steps:
         -c bats bats/tzbtc-client.bats
 
   - label: contract-doc
-    branches: "!autodoc/master !master"
+    if: *not_scheduled_autodoc
     commands:
     - nix-build ci.nix -A contract-doc-dev
     - ln -s ./result/TZBTC-contract.md TZBTC-contract.md
@@ -71,7 +86,8 @@ steps:
 
   # for master branch we include commit info in the contract doc
   - label: contract-doc (master)
-    branches: master
+    if: &not_scheduled_master
+      build.branch == "master" && build.source != "schedule"
     commands:
     - nix-build ci.nix -A contract-doc-release
         --argstr sha "$(git rev-parse HEAD)"
@@ -81,7 +97,7 @@ steps:
       - TZBTC-contract.md
 
   - label: crossref-verify generated doc
-    branches: "!autodoc/master"
+    if: *not_scheduled_autodoc
     commands:
     - mkdir tmp
     - if [ "$BUILDKITE_BRANCH" = "master" ];
@@ -94,14 +110,14 @@ steps:
     soft_fail: true  # TODO: remove
 
   - label: autodoc upload
-    branches: master
+    if: *not_scheduled_master
     commands:
     - mkdir tmp
     - buildkite-agent artifact download TZBTC-contract.md tmp/ --step "contract-doc (master)"
     - ./scripts/ci/upload-autodoc.sh
 
   - label: packaging
-    branches: "!autodoc/master"
+    if: *not_scheduled_autodoc
     commands:
     - nix-build release.nix -A static -o tzbtc-static
     - nix-build release.nix -A deb -o tzbtc-client-deb
@@ -127,3 +143,7 @@ steps:
     - nix run -f ci.nix pkgs.git -c git fetch && git tag -f auto-release && git push --force --tags
     - nix run -f ci.nix gh -c gh release create --prerelease auto-release --title auto-release --notes ""
     - nix run -f ci.nix gh -c gh release upload auto-release assets/*
+
+notify:
+  - email: "tezos-alerts@serokell.io"
+    if: build.state == "failed" && build.source == "schedule"

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -61,8 +61,6 @@ main = do
         V0 -> parseAndPrint @V0.TZBTCv0
         V1 -> parseAndPrint @V1.TZBTCv1
         V2 -> parseAndPrint @V2.TZBTCv2
-    CmdTestScenario _ver (arg #verbosity -> _verbose) (arg #dryRun -> _dryRun) -> do
-      error "Not implemented for now, will be reimplemented as a part of https://github.com/tz-wrapped/tezos-btc/issues/123"
     CmdMigrate (arg #output -> fp) migrateCmd ->
       maybe printTextLn writeFileUtf8 fp $
         case migrateCmd of

--- a/package.yaml
+++ b/package.yaml
@@ -29,11 +29,9 @@ library:
     - bytestring
     - co-log
     - containers
-    - cleveland
     - directory
     - hex-text
     - fmt
-    - lens
     - lorentz
     - morley
     - morley-ledgers
@@ -44,7 +42,6 @@ library:
     - named
     - optparse-applicative
     - megaparsec
-    - process
     - text
     - transformers
     - universum
@@ -103,6 +100,8 @@ tests:
     - morley-prelude
     - morley-upgradeable
     - mtl
+    - process
+    - tagged
     - tasty
     - tasty-hspec
     - tasty-hunit-compat

--- a/src/CLI/Parser.hs
+++ b/src/CLI/Parser.hs
@@ -22,7 +22,7 @@ import Fmt (Buildable, pretty)
 import GHC.TypeLits (KnownSymbol, symbolVal)
 import Named (Name(..), arg)
 import Options.Applicative
-  (ReadM, command, help, hsubparser, info, long, metavar, progDesc, short, switch)
+  (ReadM, command, help, hsubparser, info, long, metavar, progDesc, switch)
 import qualified Options.Applicative as Opt
 
 import Lorentz.Contracts.Metadata
@@ -39,7 +39,6 @@ data CmdLnArgs
   | CmdPrintMultisigContract Bool Bool (Maybe FilePath)
   | CmdPrintDoc VersionArg (Maybe FilePath)
   | CmdParseParameter VersionArg Text
-  | CmdTestScenario VersionArg ("verbosity" :! Word) ("dryRun" :! Bool)
   | CmdMigrate ("output" :! Maybe FilePath) MigrationArgs
 
 data VersionArg
@@ -61,7 +60,7 @@ argParser :: Opt.Parser CmdLnArgs
 argParser = hsubparser $
   printCmd <> printMultisigCmd
   <> printInitialStorageCmd <> printDoc
-  <> parseParameterCmd <> testScenarioCmd <> migrateCmd
+  <> parseParameterCmd <> migrateCmd
   where
     singleLineSwitch = onelineOption
     printCmd :: Opt.Mod Opt.CommandFields CmdLnArgs
@@ -104,15 +103,6 @@ argParser = hsubparser $
           "parseContractParameter"
           (CmdParseParameter <$> versionOption <*> Opt.strArgument mempty)
           "Parse contract parameter to Lorentz representation")
-    testScenarioCmd :: Opt.Mod Opt.CommandFields CmdLnArgs
-    testScenarioCmd =
-      (mkCommandParser
-          "testScenario"
-          (CmdTestScenario
-             <$> versionOption
-             <*> (#verbosity <.!> genericLength <$> many verbositySwitch)
-             <*> (#dryRun <.!> dryRunSwitch))
-          "Do smoke tests")
     migrateCmd :: Opt.Mod Opt.CommandFields CmdLnArgs
     migrateCmd =
       mkCommandParser
@@ -164,14 +154,6 @@ argParser = hsubparser $
          metavar "NUMBER" <>
          Opt.value V1 <>
          Opt.showDefaultWith (\_ -> "1"))
-    verbositySwitch =
-      Opt.flag' ()
-                (short 'v' <>
-                 long "verbose" <>
-                 help "Increase verbosity (pass several times to increase further)")
-    dryRunSwitch =
-      switch (long "dry-run" <>
-              help "Don't run tests over a real network.")
 
 mkCommandParser
   :: String

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,8 +6,11 @@ module Main
   ( main
   ) where
 
-import Test.Tasty (defaultMain)
+import Test.Tasty (defaultMainWithIngredients)
+
+import Cleveland.Ingredients (ourIngredients)
+
 import Tree (tests)
 
 main :: IO ()
-main = tests >>= defaultMain
+main = tests >>= defaultMainWithIngredients ourIngredients


### PR DESCRIPTION
## Description
We have some smoke tests for tzbtc and its client, which are supposed to be run manually from the developer machine.

However, nowadays we have cleveland and all the required infrastructure so that it's possible to run such tests in CI.

Currently based on #141 
<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #123 

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [x] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [x] [README](../blob/master/README.md)
    - [x] Haddock
    - [x] [docs/](../blob/master/docs/)
  - [x] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
