### PR TITLE
[Chore] Update timeout of scheduled granadanet test

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,7 +70,7 @@ steps:
     retry:
       automatic:
         limit: 1
-    timeout_in_minutes: 150
+    timeout_in_minutes: 180
 
   - label: weeder
     if: *not_scheduled_autodoc


### PR DESCRIPTION
## Description

Problem: tests on granadanet fail because the timeout that
is currently set is not long enough.

Solution: increase timeout of scheduled job to 3 hours.

## Related issue(s)

None

## :white_check_mark: Checklist for your Merge Request

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [ ] [README](../blob/master/README.md)
    - [ ] Haddock
    - [ ] [docs/](../blob/master/docs/)
  - [ ] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
