### PR TITLE
[Chore] Increase timeout of scheduled granadanet tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -70,7 +70,7 @@ steps:
     retry:
       automatic:
         limit: 1
-    timeout_in_minutes: 180
+    timeout_in_minutes: 240
 
   - label: weeder
     if: *not_scheduled_autodoc


### PR DESCRIPTION
## Description

Problem: after the recent updates to the node endpoint used the
timeout for the scheduled granadanet tests is no longer sufficient.

Solution: increase that timeout in the pipeline.

## Related issue(s)

None

## :white_check_mark: Checklist for your Merge Request

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [ ] [README](../blob/master/README.md)
    - [ ] Haddock
    - [ ] [docs/](../blob/master/docs/)
  - [ ] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
