### PR TITLE
[#160] Examine bigmaps in non-emulated nettests

### DIFF
--- a/test/Test/AsRPC.hs
+++ b/test/Test/AsRPC.hs
@@ -1,0 +1,23 @@
+{- SPDX-FileCopyrightText: 2021 Bitcoin Suisse
+ -
+ - SPDX-License-Identifier: LicenseRef-MIT-BitcoinSuisse
+ -}
+
+{-# LANGUAGE DeriveAnyClass #-}
+
+module Test.AsRPC (StorageRPC(..)) where
+
+import Lorentz.Contracts.Metadata (TokenMetadata)
+import Lorentz.Contracts.TZBTC.V0 (Storage)
+import Lorentz.Contracts.TZBTC.V1.Types (StorageFields)
+import Michelson.Typed.Haskell.Value (BigMapId, IsoValue)
+import Morley.Nettest (AsRPC)
+
+data StorageRPC ver = StorageRPC
+  { dataMap :: BigMapId ByteString ByteString
+  , fields :: StorageFields ver
+  } deriving stock (Generic, Show)
+    deriving anyclass (IsoValue)
+
+type instance AsRPC (Storage ver) = StorageRPC ver
+type instance AsRPC TokenMetadata = TokenMetadata

--- a/test/Test/Migration.hs
+++ b/test/Test/Migration.hs
@@ -29,6 +29,7 @@ import Morley.Nettest
 import Morley.Nettest.Tasty
 import Tezos.Address (Address, ta)
 
+import qualified Test.AsRPC as RPC
 import Test.TZBTC (dummyV1Parameters)
 
 {-# ANN module ("HLint: ignore Reduce duplication" :: Text) #-}
@@ -112,15 +113,14 @@ test_migratingStatus = testGroup "TZBTC contract migration status active check"
 -- Test that migration bumps version
 test_migratingVersion :: TestTree
 test_migratingVersion = testGroup "TZBTC contract migration version check"
-  -- TODO: use nettestScenarioCaps once cleveland dependency is updated
-  [ nettestScenarioOnEmulatorCaps "Test EpwFinishUpgrade bumps version" $ do
+  [ nettestScenarioCaps "Test EpwFinishUpgrade bumps version" $ do
       admin <- newAddress "admin"
       v0 <- originateSimple "tzbtc" (mkEmptyStorageV0 admin) tzbtcContract
       withSender admin $ do
         call v0 CallDefault $ fromFlatParameter $ EpwBeginUpgrade (#current .! 0, #new .! 1)
         call v0 CallDefault $ fromFlatParameter EpwFinishUpgrade
-      storage <- getFullStorage v0
-      assert ((TZBTCTypes.currentVersion . TZBTCTypes.fields) storage == 1)
+      storage <- getStorage v0
+      assert ((TZBTCTypes.currentVersion . RPC.fields) storage == 1)
         "Version was not updated"
   ]
 

--- a/test/Test/MultiSig.hs
+++ b/test/Test/MultiSig.hs
@@ -15,9 +15,9 @@ import Test.Tasty.HUnit (testCase)
 
 import Lorentz hiding (assert, chainId)
 import Lorentz.Contracts.Multisig
-import Lorentz.Contracts.Test.ManagedLedger (OriginationParams(..))
 import Lorentz.Contracts.TZBTC as TZBTC
 import qualified Lorentz.Contracts.TZBTC.Types as TZBTCTypes (SafeParameter(..))
+import Lorentz.Contracts.Test.ManagedLedger (OriginationParams(..))
 import Lorentz.Test.Integrational (genesisAddress3, genesisAddress5)
 import Morley.Nettest
 import Morley.Nettest.Tasty
@@ -69,7 +69,7 @@ sign_ sk bs = case decodeHex (T.drop 2 bs) of
 
 test_multisig :: TestTree
 test_multisig = testGroup "TZBTC contract multi-sig functionality test"
-  [ nettestScenarioOnEmulatorCaps "Test call to multisig to add an operator works" $ do
+  [ nettestScenarioCaps "Test call to multisig to add an operator works" $ do
       -- Originate multisig with threshold 2 and a master pk list of
       -- three public keys
       withMultiSigContract 0 2 masterPKList $ \msig -> do
@@ -94,8 +94,8 @@ test_multisig = testGroup "TZBTC contract multi-sig functionality test"
             MSig.mkMultiSigParam masterPKList ((alicePackage) :| [carlosPackage])
         -- Finally call the multisig contract
         call msig (Call @"MainParameter") mparam
-        st <- getFullStorage tzbtc
-        assert (checkField (getOperators @TZBTCv1) (Set.member operatorAddress) st)
+        st <- getStorage tzbtc
+        checkField (getOperators @TZBTCv1) (Set.member operatorAddress) st
           "New operator not found"
 
   , nettestScenarioCaps "Test call to multisig to add an operator fails with one signature less" $ do
@@ -175,7 +175,7 @@ test_multisig = testGroup "TZBTC contract multi-sig functionality test"
         -- Now call again with the same param, this should fail.
         expectCustomError_ #counterDoesntMatch $
           call msaddr (Call @"MainParameter") mparam
-  , nettestScenarioOnEmulatorCaps "Test signed bundle created for one msig contract does not work on other" $ do
+  , nettestScenarioCaps "Test signed bundle created for one msig contract does not work on other" $ do
       -- Originate multisig with threshold 2 and a master pk list of
       -- three public keys
       withMultiSigContract 0 2 masterPKList $ \msig -> do
@@ -207,8 +207,8 @@ test_multisig = testGroup "TZBTC contract multi-sig functionality test"
         -- Call the actual contract with the bundle. Should work as
         -- expected.
         call msaddr (Call @"MainParameter") mparam
-        st <- getFullStorage tzbtc
-        assert (checkField (getOperators @TZBTCv1) (Set.member operatorAddress) st)
+        st <- getStorage tzbtc
+        checkField (getOperators @TZBTCv1) (Set.member operatorAddress) st
           "New operator not found"
 
         -- Call the clone with the bundle created for the real multisig


### PR DESCRIPTION
## Description

<!--
Describes the nature of your changes. If they are substantial, you should
further subdivide this into a section describing the problem you are solving and
another describing your solution.
-->
Problem: some tests run only on emulated environment due to using
`getFullStorage`. We can rewrite those to run on the real chain.

Solution: working with UStore from Haskell is a little tricky, so
I wrote a helper 'readUStore' which gets an element from UStore given
a 'UStoreElemRef' and a big map id. The rest is pretty straightforward.


## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #160

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [x] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [ ] [README](../blob/master/README.md)
    - [ ] Haddock
    - [ ] [docs/](../blob/master/docs/)
  - [ ] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
