### PR TITLE
[Chore] Remove tests from CI for protocol 010

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -50,34 +50,16 @@ steps:
     - nix-build ci.nix -A tzbtc.components.tests.tzbtc-test
     - ./result/bin/tzbtc-test --nettest-mode=disable-network
 
-  - label: test-local-chain-010
-    if: *not_scheduled_autodoc
-    depends_on: build
-    env:
-      TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8733"
-    commands: &run-nettest
-    - nix-build ci.nix -A tzbtc.components.tests.tzbtc-test
-    - export TASTY_NETTEST_DATA_DIR="$(mktemp -d --tmpdir="$$PWD")"
-    - nix run -f ci.nix tezos-client tzbtc.components.exes.tzbtc-client -c ./result/bin/tzbtc-test
-      --nettest-mode=only-network
-
   - label: test-local-chain-011
     if: *not_scheduled_autodoc
     depends_on: build
     env:
       TASTY_NETTEST_NODE_ENDPOINT: "http://localhost:8734"
-    commands: *run-nettest
-
-  - label: scheduled granadanet test
-    if: build.source == "schedule"
-    depends_on: build
-    env:
-      TASTY_NETTEST_NODE_ENDPOINT: "https://granada.testnet.tezos.serokell.team"
-    commands: *run-nettest
-    retry:
-      automatic:
-        limit: 1
-    timeout_in_minutes: 240
+    commands: &run-nettest
+    - nix-build ci.nix -A tzbtc.components.tests.tzbtc-test
+    - export TASTY_NETTEST_DATA_DIR="$(mktemp -d --tmpdir="$$PWD")"
+    - nix run -f ci.nix tezos-client tzbtc.components.exes.tzbtc-client -c ./result/bin/tzbtc-test
+      --nettest-mode=only-network
 
   - label: scheduled hangzhounet test
     if: build.source == "schedule"


### PR DESCRIPTION
## Description

The granada/010 protocol is no longer active on mainnet and its testnet is no longer relevant to us.

This removes the tests on CI based on said protocol

## Related issue(s)

[TM-603](https://issues.serokell.io/issue/TM-603)

## :white_check_mark: Checklist for your Merge Request

#### Related changes (conditional)


- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [ ] [README](../blob/master/README.md)
    - [ ] Haddock
    - [ ] [docs/](../blob/master/docs/)
  - [ ] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
