### PR TITLE
[#173] Use refillable addresses

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -69,7 +69,7 @@ steps:
       automatic:
         limit: 1
 
-  - label: scheduled jakartanet test
+  - label: scheduled kathmandunet test
     if: build.source == "schedule"
     depends_on: build
     env:

--- a/test/Test/Migration.hs
+++ b/test/Test/Migration.hs
@@ -37,26 +37,26 @@ import Test.TZBTC (dummyV1Parameters)
 test_ownerCheck :: TestTree
 test_ownerCheck = testGroup "TZBTC contract migration endpoints test"
   [ testScenario "Test call to administrative endpoints are only available to owner" $ scenario $ do
-      admin <- newAddress "admin"
-      bob <- newAddress "bob"
+      admin <- refillable $ newAddress "admin"
+      bob <- refillable $ newAddress "bob"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       expectCustomError_ #senderIsNotOwner $ withSender bob $
         transfer v0 $ calling def $ fromFlatParameter $ EpwBeginUpgrade (#current :! 0, #new :! 1)
   , testScenario "Test call to `ApplyMigration` endpoints are only available to owner" $ scenario $ do
-      admin <- newAddress "admin"
-      bob <- newAddress "bob"
+      admin <- refillable $ newAddress "admin"
+      bob <- refillable $ newAddress "bob"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       expectCustomError_ #senderIsNotOwner $ withSender bob $
         transfer v0 $ calling def $ fromFlatParameter $ EpwApplyMigration (checkedCoerce migrationScriptV1)
   , testScenario "Test call to `SetCode` endpoints are only available to owner" $ scenario $ do
-      admin <- newAddress "admin"
-      bob <- newAddress "bob"
+      admin <- refillable $ newAddress "admin"
+      bob <- refillable $ newAddress "bob"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       expectCustomError_ #senderIsNotOwner $ withSender bob $
         transfer v0 $ calling def $ fromFlatParameter $ EpwSetCode emptyCode
   , testScenario "Test call to `EpwFinishUpgrade` endpoints are only available to owner" $ scenario $ do
-      admin <- newAddress "admin"
-      bob <- newAddress "bob"
+      admin <- refillable $ newAddress "admin"
+      bob <- refillable $ newAddress "bob"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       expectCustomError_ #senderIsNotOwner $ withSender bob $
         transfer v0 $ calling def $ fromFlatParameter $ EpwFinishUpgrade
@@ -66,17 +66,17 @@ test_ownerCheck = testGroup "TZBTC contract migration endpoints test"
 test_notMigratingStatus :: TestTree
 test_notMigratingStatus = testGroup "TZBTC contract migration status not active check"
   [ testScenario "Test call to `ApplyMigration` that require a migrating state fails in non migrating state" $ scenario $ do
-      admin <- newAddress "admin"
+      admin <- refillable $ newAddress "admin"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       expectCustomError_ #upgContractIsNotMigrating $ withSender admin $
         transfer v0 $ calling def $ fromFlatParameter $ EpwApplyMigration (checkedCoerce migrationScriptV1)
   , testScenario "Test call to `EpwSetCode` that require a non-migrating state fails in migrating state" $ scenario $ do
-      admin <- newAddress "admin"
+      admin <- refillable $ newAddress "admin"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       expectCustomError_ #upgContractIsNotMigrating $ withSender admin $
         transfer v0 $ calling def $ fromFlatParameter $ EpwSetCode emptyCode
   , testScenario "Test call to `EpwFinishUpgrade` that require a non-migrating state fails in migrating state" $ scenario $ do
-      admin <- newAddress "admin"
+      admin <- refillable $ newAddress "admin"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       expectCustomError_ #upgContractIsNotMigrating $ withSender admin $
         transfer v0 $ calling def $ fromFlatParameter $ EpwFinishUpgrade
@@ -86,21 +86,21 @@ test_notMigratingStatus = testGroup "TZBTC contract migration status not active 
 test_migratingStatus :: TestTree
 test_migratingStatus = testGroup "TZBTC contract migration status active check"
   [ testScenario "Test call to `Upgrade` that require a non-migrating state fails in migrating state" $ scenario $ do
-      admin <- newAddress "admin"
+      admin <- refillable $ newAddress "admin"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       withSender admin $ do
         transfer v0 $ calling def $ fromFlatParameter $ EpwBeginUpgrade (#current :! 0, #new :! 1)
         expectCustomError_ #upgContractIsMigrating $
           transfer v0 $ calling def $ fromFlatParameter $ Upgrade upgradeParamsV1
   , testScenario "Test call to `Run` that require a non-migrating state fails in migrating state" $ scenario $ do
-      admin <- newAddress "admin"
+      admin <- refillable $ newAddress "admin"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       withSender admin $ do
         transfer v0 $ calling def $ fromFlatParameter $ EpwBeginUpgrade (#current :! 0, #new :! 1)
         expectCustomError_ #upgContractIsMigrating $
           transfer v0 $ calling def $ fromFlatParameter $ Run $ mkUParam #callBurn (#value :! 100)
   , testScenario "Test call to `Burn` that require a non-migrating state fails in migrating state" $ scenario $ do
-      admin <- newAddress "admin"
+      admin <- refillable $ newAddress "admin"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       withSender admin $ do
         transfer v0 $ calling def $ fromFlatParameter $ EpwBeginUpgrade (#current :! 0, #new :! 1)
@@ -112,7 +112,7 @@ test_migratingStatus = testGroup "TZBTC contract migration status active check"
 test_migratingVersion :: TestTree
 test_migratingVersion = testGroup "TZBTC contract migration version check"
   [ testScenario "Test EpwFinishUpgrade bumps version" $ scenario $ do
-      admin <- newAddress "admin"
+      admin <- refillable $ newAddress "admin"
       v0 <- originate "tzbtc" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
       withSender admin $ do
         transfer v0 $ calling def $ fromFlatParameter $ EpwBeginUpgrade (#current :! 0, #new :! 1)

--- a/test/Test/MultiSig.hs
+++ b/test/Test/MultiSig.hs
@@ -276,7 +276,7 @@ test_multisig = testGroup "TZBTC contract multi-sig functionality test"
       => ContractHandle MSigParameter MSigStorage ()
       -> m (ContractHandle (TZBTC.Parameter TZBTCv1) (TZBTC.Storage TZBTCv1) ())
     originateTzbtc msig = do
-      admin <- newAddress auto
+      admin <- refillable $ newAddress auto
       chainId <- getChainId
       redeem <- newFreshAddress "redeem"
       tzbtc <- originateTzbtcV1ContractRaw redeem $ OriginationParams

--- a/test/Test/Smoke.hs
+++ b/test/Test/Smoke.hs
@@ -110,7 +110,6 @@ testUpgradeToV1 = TestUpgrade $ \admin redeem balances tzbtc -> do
       , upNewCode = tzbtcContractRouterV1
       , upNewPermCode = emptyPermanentImplCompat
       }
-  transfer admin [tz|50|] -- 50 XTZ
   withSender admin $ transfer tzbtc $ calling def
     (fromFlatParameter $ Upgrade upgradeParams :: Parameter TZBTCv0)
 
@@ -126,7 +125,6 @@ testUpgradeToV2 = TestUpgrade $ \admin redeem balances tzbtc -> do
       , upNewCode = tzbtcContractRouterV2
       , upNewPermCode = emptyPermanentImplCompat
       }
-  transfer admin [tz|50|] -- 50 XTZ
   withSender admin $ transfer tzbtc $ unsafeCalling def
     (fromFlatParameter $ Upgrade upgradeParams :: Parameter TZBTCv0)
 
@@ -134,13 +132,13 @@ simpleScenario
   :: (MonadFail m, MonadCleveland caps m)
   => TestUpgrade m -> m ()
 simpleScenario upg = do
-  admin <- newAddress "admin"
+  admin <- refillable $ newAddress "admin"
 
   -- TODO [morley#887]: currently there's a hard implicit limit on 5 ops per
   -- batch, we could also create "guest" in the batch otherwise.
   operator ::< operatorToRemove ::< alice ::< john ::< newOwner ::< Nil' <-
     newAddresses $ "operator" :< "operator_to_remove" :< "alice" :< "john" :< "newOwner" :< Nil
-  guest <- newAddress "guest"
+  guest <- refillable $ newAddress "guest"
 
   transfer admin [tz|15|]
   -- Originate and upgrade

--- a/test/Test/Smoke.hs
+++ b/test/Test/Smoke.hs
@@ -31,9 +31,9 @@ import Morley.Client (OperationInfo(..), disableAlphanetWarning)
 import Morley.Client.TezosClient qualified as TezosClient
 import Morley.Michelson.Typed.Haskell.Value
 import Morley.Tezos.Address
-import Morley.Tezos.Core
 import Morley.Util.Named
 import Morley.Util.Sing (castSing)
+import Morley.Util.SizedList (SizedList'(..))
 import Test.Cleveland
 import Test.Cleveland.Internal.Abstract
 import Test.Cleveland.Internal.Client
@@ -131,25 +131,31 @@ testUpgradeToV2 = TestUpgrade $ \admin redeem balances tzbtc -> do
     (fromFlatParameter $ Upgrade upgradeParams :: Parameter TZBTCv0)
 
 simpleScenario
-  :: MonadCleveland caps m
+  :: (MonadFail m, MonadCleveland caps m)
   => TestUpgrade m -> m ()
 simpleScenario upg = do
-  -- admin <- resolveNettestAddress -- Fetch address for alias `nettest`.
   admin <- newAddress "admin"
+
+  -- TODO [morley#887]: currently there's a hard implicit limit on 5 ops per
+  -- batch, we could also create "guest" in the batch otherwise.
+  operator ::< operatorToRemove ::< alice ::< john ::< newOwner ::< Nil' <-
+    newAddresses $ "operator" :< "operator_to_remove" :< "alice" :< "john" :< "newOwner" :< Nil
+  guest <- newAddress "guest"
+
   transfer admin [tz|15|]
   -- Originate and upgrade
   -- sender is made an admin in the tzbtc-client based implementation
   tzbtc <- withSender admin $
     originate "TZBTCContract" (mkEmptyStorageV0 $ toL1Address admin) tzbtcContract
 
-  -- Originate Address view callback
-  addressView <- originate "Address view" [] (contractConsumer @Address)
-
-  -- Originate Natural view callback
-  naturalView <- originate "Natural view" [] (contractConsumer @Natural)
-
-  -- Originate [TokenMetadata] view callback
-  tokenMetadatasView <- originate "[TokenMetadata] view" [] (contractConsumer @[TokenMetadata])
+  (addressView, naturalView, tokenMetadatasView) <- inBatch $ do
+    -- Originate Address view callback
+    av <- originate "Address view" [] (contractConsumer @Address)
+    -- Originate Natural view callback
+    nv <- originate "Natural view" [] (contractConsumer @Natural)
+    -- Originate [TokenMetadata] view callback
+    tmv <- originate "[TokenMetadata] view" [] (contractConsumer @[TokenMetadata])
+    pure (av, nv, tmv)
 
   -- Run upgrade
   unTestUpgrade upg admin admin mempty tzbtc
@@ -159,8 +165,6 @@ simpleScenario upg = do
     fromFlatParameterV1 = fromFlatParameter
 
   -- Add an operator
-  operator <- newAddress "operator"
-  operatorToRemove <- newAddress "operator_to_remove"
 
   withSender admin $ do
     transfer tzbtc $ unsafeCalling def
@@ -171,7 +175,6 @@ simpleScenario upg = do
       (fromFlatParameterV1 $ AddOperator (#operator :! toAddress operatorToRemove))
 
   -- Mint some coins for alice
-  alice <- newAddress "alice"
 
   -- use the new operator to make sure it has been added.
   withSender operatorToRemove $ transfer tzbtc $ unsafeCalling def
@@ -184,7 +187,6 @@ simpleScenario upg = do
 
   -- Set allowance
   -- Mint some coins for john
-  john <- newAddress "john"
 
   withSender operator $ transfer tzbtc $ unsafeCalling def
     -- We use alias instead of address to let the nettest implementation
@@ -215,7 +217,6 @@ simpleScenario upg = do
       (fromFlatParameterV1 $ Pause ())
 
   -- Resume operations
-  newOwner <- newAddress "newOwner"
   withSender admin $ do
     transfer tzbtc $ unsafeCalling def
       (fromFlatParameterV1 $ Unpause ())
@@ -229,7 +230,6 @@ simpleScenario upg = do
     (fromFlatParameterV1 $ AcceptOwnership ())
 
   -- Make an anonymous address
-  guest <- newAddress "guest"
 
   withSender guest $ do
     transfer tzbtc $ unsafeCalling def
@@ -277,16 +277,12 @@ runNettestTzbtcClient env scenario' = do
   runReaderT (unClientM clientM) ist
 
 nettestImplTzbtcClient :: MorleyClientEnv -> Sender -> ClevelandOpsImpl ClientM
-nettestImplTzbtcClient env sender =
-  impl { coiRunOperationBatch = \case
-      [] -> pure [] -- this happens when `newAddress` reuses addresses that have enough tez
-      [op] -> case op of
-        OpOriginate oud -> tzbtcClientOriginate oud
-        OpTransfer td -> tzbtcClientTransfer td >> pure [OpTransfer []]
-        OpReveal _ -> error "Reveal operation is not supported"
-      _ -> error "Batch operations are not supported"
-    }
+nettestImplTzbtcClient env sender = impl { coiRunOperationBatch = concatMapM runOp }
   where
+    runOp = \case
+      OpOriginate oud -> tzbtcClientOriginate oud
+      OpTransfer td -> tzbtcClientTransfer td >> pure [OpTransfer []]
+      OpReveal _ -> error "Reveal operation is not supported"
     impl = networkOpsImpl env sender
 
     tezosClientEnv = mceTezosClient env

--- a/test/Test/TZBTC.hs
+++ b/test/Test/TZBTC.hs
@@ -248,19 +248,19 @@ test_addOperator = testGroup "TZBTC contract `addOperator` test"
   [ testContract
       "Call to `addOperator` from random address gets denied with `senderIsNotOwner` error." $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        bob <- newAddress auto
-        operator <- newAddress auto
+        bob <- refillable $ newAddress auto
+        operator <- refillable $ newAddress auto
         withSender bob $
           expectCustomError_ #senderIsNotOwner $ transfer c $ calling def $
           fromFlatParameter $ AddOperator (#operator :! toAddress operator)
   , testContract
       "Call to `addOperator` from owner adds operator to the set." $
       \originateContract (_ :: Proxy ver) -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        operator <- newAddress auto
+        operator <- refillable $ newAddress auto
         withSender admin $
           transfer c $ calling def $ fromFlatParameter $ AddOperator (#operator :! toAddress operator)
         st <- getStorage c
@@ -273,10 +273,10 @@ test_removeOperator = testGroup "TZBTC contract `addOperator` test"
   [ testContract
       "Call to `removeOperator` from random address gets denied with `senderIsNotOwner` error." $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        bob <- newAddress auto
-        operator <- newAddress auto
+        bob <- refillable $ newAddress auto
+        operator <- refillable $ newAddress auto
         withSender bob $
           expectCustomError_ #senderIsNotOwner $
           transfer c $ calling def $ fromFlatParameter $ RemoveOperator (#operator :! toAddress operator)
@@ -284,9 +284,9 @@ test_removeOperator = testGroup "TZBTC contract `addOperator` test"
   , testContract
       "Call to `removeOperator` from owner removes operator from the set." $
       \originateContract (_ :: Proxy ver) -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        operator <- newAddress auto
+        operator <- refillable $ newAddress auto
         withSender admin $ transfer c $ calling def $ fromFlatParameter $ AddOperator (#operator :! toAddress operator)
         st1 <- getStorage c
         checkField (getOperators @ver) (Set.member $ toAddress operator) st1
@@ -302,18 +302,18 @@ test_transferOwnership = testGroup "TZBTC contract `transferOwnership` test"
   [ testContract
       "Call to `transferOwnership` from random address gets denied with `senderIsNotOwner` error." $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        bob <- newAddress auto
-        replaceAddress <- newAddress "replaceAddress"
+        bob <- refillable $ newAddress auto
+        replaceAddress <- refillable $ newAddress "replaceAddress"
         withSender bob $ expectCustomError_ #senderIsNotOwner $
           transfer c $ calling def $ fromFlatParameter $ TransferOwnership (#newOwner :! toAddress replaceAddress)
   , testContract
       "Call to `transferOwnership` from owner address gets denied with `senderIsNotOwner` error." $
       \originateContract (_ :: Proxy ver) -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        replaceAddress <- newAddress auto
+        replaceAddress <- refillable $ newAddress auto
         withSender admin $
           transfer c $ calling def $ fromFlatParameter $ TransferOwnership (#newOwner :! toAddress replaceAddress)
         st <- getStorage c
@@ -326,18 +326,18 @@ test_acceptOwnership = testGroup "TZBTC contract `acceptOwnership` test"
   [ testContract
       "Call to `acceptOwnership` to non-transfering contract gets denied with `notInTransferOwnershipMode` error " $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        bob <- newAddress auto
+        bob <- refillable $ newAddress auto
         withSender bob $ expectCustomError_ #notInTransferOwnershipMode $
           transfer c $ calling def $ fromFlatParameter $ AcceptOwnership ()
   , testContract
       "Call to `acceptOwnership` to transferring contract from random address gets denied with `senderIsNotNewOwner` error." $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        bob <- newAddress auto
-        replaceAddress <- newAddress auto
+        bob <- refillable $ newAddress auto
+        replaceAddress <- refillable $ newAddress auto
         withSender admin $
           transfer c $ calling def $ fromFlatParameter $ TransferOwnership (#newOwner :! toAddress replaceAddress)
         withSender bob $ expectCustomError_ #senderIsNotNewOwner $
@@ -345,9 +345,9 @@ test_acceptOwnership = testGroup "TZBTC contract `acceptOwnership` test"
   , testContract
       "Call to `acceptOwnership` to transferring contract from random address gets denied with `senderIsNotNewOwner` error." $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        replaceAddress <- newAddress auto
+        replaceAddress <- refillable $ newAddress auto
         withSender admin $
           transfer c $ calling def $ fromFlatParameter $ TransferOwnership (#newOwner :! toAddress replaceAddress)
         withSender replaceAddress $ do
@@ -359,9 +359,9 @@ test_acceptOwnership = testGroup "TZBTC contract `acceptOwnership` test"
   , testContract
       "Call to `acceptOwnership` to transferring contract from current address gets denied with `senderIsNotNewOwner` error." $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        replaceAddress <- newAddress auto
+        replaceAddress <- refillable $ newAddress auto
         withSender admin $
           transfer c $ calling def $ fromFlatParameter $ TransferOwnership (#newOwner :! toAddress replaceAddress)
         expectCustomError_ #senderIsNotNewOwner $
@@ -373,18 +373,18 @@ test_setRedeemAddress = testGroup "TZBTC contract `setRedeemAddress` test"
   [ testContract
       "Call to `setRedeemAddress` from random address is denied with `SenderIsNotOwner` error" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        replaceAddress <- newAddress auto
-        bob <- newAddress auto
+        replaceAddress <- refillable $ newAddress auto
+        bob <- refillable $ newAddress auto
         withSender bob $ expectCustomError_ #senderIsNotOwner $
           transfer c $ calling def $ fromFlatParameter $ SetRedeemAddress (#redeem :! toAddress replaceAddress)
   , testContract
       "Call to `setRedeemAddress` sets redeem address correctly" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        replaceAddress <- newAddress auto
+        replaceAddress <- refillable $ newAddress auto
         withSender admin $
           transfer c $ calling def $ fromFlatParameter $ SetRedeemAddress (#redeem :! toAddress replaceAddress)
         consumer <- originate "consumer" [] contractConsumer
@@ -398,24 +398,24 @@ test_burn = testGroup "TZBTC contract `burn` test"
   [ testContract
       "Call to `burn` from random address is denied with `SenderIsNotOperator` error" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        bob <- newAddress auto
+        bob <- refillable $ newAddress auto
         withSender bob $ expectCustomError_ #senderIsNotOperator $
           transfer c $ calling def $ fromFlatParameter $ Burn (#value :! 100)
   , testContract
       "Call to `burn` from owner address is denied with `SenderIsNotOperator` error" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
         withSender admin $ expectCustomError_ #senderIsNotOperator $
           transfer c $ calling def $ fromFlatParameter $ Burn (#value :! 100)
   , testContract
       "Call to `burn` from operator subtracts from redeemAddress and update bookkeeping fields" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        operator <- newAddress "operator"
+        operator <- refillable $ newAddress "operator"
         consumer <- originate "consumer" [] contractConsumer
 
         -- Add an operator
@@ -447,27 +447,27 @@ test_mint = testGroup "TZBTC contract `mint` test"
   [ testContract
       "Call to `mint` from random address is denied with `SenderIsNotOperator` error" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        alice <- newAddress auto
-        bob <- newAddress auto
+        alice <- refillable $ newAddress auto
+        bob <- refillable $ newAddress auto
         withSender bob $ expectCustomError_ #senderIsNotOperator $
           transfer c $ calling def $ fromFlatParameter $ Mint (#to :! toAddress alice, #value :! 100)
   , testContract
       "Call to `mint` from owner address is denied with `SenderIsNotOperator` error" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        alice <- newAddress auto
+        alice <- refillable $ newAddress auto
         withSender admin $ expectCustomError_ #senderIsNotOperator $
           transfer c $ calling def $ fromFlatParameter $ Mint (#to :! toAddress alice, #value :! 100)
   , testContract
       "Call to `mint` from operator adds to account and update bookkeeping fields" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        operator <- newAddress "operator"
-        alice <- newAddress auto
+        operator <- refillable $ newAddress "operator"
+        alice <- refillable $ newAddress auto
         consumer <- originate "consumer" [] contractConsumer
 
         -- Add an operator
@@ -506,7 +506,7 @@ test_approvableLedgerV1 = testGroup "TZBTC contract approvable ledger tests"
       :: (MonadCleveland caps m)
       => ImplicitAddress -> AL.AlSettings -> m (ContractHandle (Parameter TZBTCv1) (Storage TZBTCv1) ())
     alOriginate = originateManagedLedger $ \op  -> do
-      let owner = case ML.opAdmin op of
+      owner <- refillable $ pure $ case ML.opAdmin op of
             MkAddress x@ImplicitAddress{} -> x
             _ -> error "Unexpected address type in alOriginate"
       c <- originate "TZBTC Contract" (mkEmptyStorageV0 $ toL1Address owner) tzbtcContract
@@ -527,7 +527,7 @@ test_approvableLedgerV2 :: TestTree
 test_approvableLedgerV2 = testGroup "TZBTC contract approvable ledger tests"
   [ AL.approvableLedgerGenericTest @(Parameter SomeTZBTCVersion) @(Storage SomeTZBTCVersion) $
     originateManagedLedger $ \op -> do
-      let owner = case ML.opAdmin op of
+      owner <- refillable $ pure $ case ML.opAdmin op of
             MkAddress x@ImplicitAddress{} -> x
             _ -> error "Unexpected address type in originateManagedLedger"
       c <- originate "TZBTC Contract" (mkEmptyStorageV0 $ toL1Address owner) tzbtcContract
@@ -550,24 +550,24 @@ test_pause = testGroup "TZBTC contract `pause` test"
   [ testContract
       "Call to `pause` from random address is denied with `SenderIsNotOperator` error" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        bob <- newAddress auto
+        bob <- refillable $ newAddress auto
         withSender bob $ expectCustomError_ #senderIsNotOperator $
           transfer c $ calling def $ fromFlatParameter $ Pause ()
   , testContract
       "Call to `pause` from owner address is denied with `SenderIsNotOperator` error" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
         withSender admin $ expectCustomError_ #senderIsNotOperator $
           transfer c $ calling def $ fromFlatParameter $ Pause ()
   , testContract
       "Call to `pause` from operator sets the paused status" $
       \originateContract (_ :: Proxy ver) -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        operator <- newAddress "operator"
+        operator <- refillable $ newAddress "operator"
         -- Add an operator
         withSender admin $ transfer c $ calling def $ fromFlatParameter $ AddOperator (#operator :! toAddress operator)
 
@@ -584,17 +584,17 @@ test_unpause = testGroup "TZBTC contract `unpause` test"
   [ testContract
       "Call to `unpause` from random address is denied with `SenderIsNotOwner` error" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        bob <- newAddress "bob"
+        bob <- refillable $ newAddress "bob"
         withSender bob $ expectCustomError_ #senderIsNotOwner $
           transfer c $ calling def $ fromFlatParameter $ Unpause ()
   , testContract
       "Call to `unpause` from operator address is denied with `SenderIsNotOwner` error" $
       \originateContract _ -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        operator <- newAddress "operator"
+        operator <- refillable $ newAddress "operator"
         -- Add an operator
         withSender admin $ transfer c $ calling def $ fromFlatParameter $ AddOperator (#operator :! toAddress operator)
         withSender operator $ expectCustomError_ #senderIsNotOwner $
@@ -602,9 +602,9 @@ test_unpause = testGroup "TZBTC contract `unpause` test"
   , testContract
       "Call to `unpause` from owner unsets the paused status" $
       \originateContract (_ :: Proxy ver) -> do
-        admin <- newAddress "admin"
+        admin <- refillable $ newAddress "admin"
         c <- originateContract $ toAddress admin
-        operator <- newAddress "operator"
+        operator <- refillable $ newAddress "operator"
         -- Add an operator
         withSender admin $ transfer c $ calling def $ fromFlatParameter $ AddOperator (#operator :! toAddress operator)
         -- Pause the contract
@@ -625,10 +625,10 @@ test_bookkeeping = testGroup "TZBTC contract bookkeeping views test"
   [ testContract
       "calling book keeping views returns expected result" $
       \originateContract _ -> do
-          admin <- newAddress "admin"
+          admin <- refillable $ newAddress "admin"
           v1 <- originateContract $ toAddress admin
-          operator <- newAddress "operator"
-          alice <- newAddress "alice"
+          operator <- refillable $ newAddress "operator"
+          alice <- refillable $ newAddress "alice"
           -- Add an operator
           withSender admin $ transfer v1 $ calling def $ fromFlatParameter $ AddOperator (#operator :! toAddress operator)
           withSender operator $ do
@@ -658,7 +658,7 @@ test_get_meta :: TestTree
 test_get_meta =
   testContract "Can get TZBTC metadata" $
     \originateContract _ -> do
-      admin <- newAddress "admin"
+      admin <- refillable $ newAddress "admin"
       v1 <- originateContract $ toAddress admin
       consumer <- originate "consumer" [] contractConsumer
       transfer v1 $ calling def $ fromFlatParameter $ GetTokenMetadata (mkView_ [singleTokenTokenId] consumer)


### PR DESCRIPTION
## Description

Problem: We could stand to run smoke tests a little faster.

Solution: Batch some originations and transfers in smoke tests running
through Cleveland; modify tests running through tzbtc-client to
"emulate" batched transfers.

Problem: tests tend to error out with insufficient balance errors. We
hard-code some amounts in tests, but this is error-prone and not always
sufficient.

Solution: Use refillable addresses everywhere. This is basically free
for cases that don't need refills, and will mostlysave us from running
out of funds mid-test.

One particular hard-coded transfer has to be left in place because
that's running through tzbtc-client, and tzbtc-client doesn't do
refills.

**Discussion point**: The alternative to hard-coding a transfer, we could just as well set the "admin" to moneybag address in smoke tests. This would make the tests very slightly less robust, but it'll work without hard-coded transfer amounts.

## Related issue(s)

<!--
- Short description of how the PR relates to the issue, including an issue link.
For example
- Fixed #999 by adding lenses to exported items

Write 'None' if there are no related issues (which is discouraged).
-->

Resolves #173

## :white_check_mark: Checklist for your Merge Request

<!--
Ideally a PR has all of the checkmarks set.

If something in this list is irrelevant to your PR, you should still set this
checkmark indicating that you are sure it is dealt with (be that by irrelevance).

If you don't set a checkmark (e. g. don't add a test for new functionality),
you must be able to justify that.
-->

#### Related changes (conditional)

- Tests (see [short guidelines](../blob/master/CONTRIBUTING.md#tests))
  - [ ] If I added new functionality, I added tests covering it.
  - [ ] If I fixed a bug, I added a regression test to prevent the bug from
        silently reappearing again.

- Documentation
  - I checked whether I should update the docs and did so if necessary:
    - [ ] [README](../blob/master/README.md)
    - [ ] Haddock
    - [ ] [docs/](../blob/master/docs/)
  - [ ] I updated [changelog](../blob/master/ChangeLog.md) unless I am sure my changes are
        really minor.

#### Stylistic guide (mandatory)

- [x] My commits comply with [the following policy](https://www.notion.so/serokell/Where-and-how-to-commit-your-work-58f8973a4b3142c8abbd2e6fd5b3a08e).
- [x] My code complies with the [style guide](../blob/master/docs/code-style.md).
